### PR TITLE
HWKAPM-474 Add 'type' field to Property, to enable support for numeri…

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/model/Property.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/Property.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * This class represents a property.
  *
@@ -28,9 +31,17 @@ import java.io.ObjectOutput;
  */
 public class Property implements Externalizable {
 
+    @JsonInclude(Include.NON_NULL)
     private String name;
 
-    private String text;
+    @JsonInclude(Include.NON_NULL)
+    private String value;
+
+    @JsonInclude(Include.NON_DEFAULT)
+    private PropertyType type = PropertyType.Text;
+
+    @JsonInclude(Include.NON_NULL)
+    private Double number;
 
     /**
      * The default constructor.
@@ -42,11 +53,11 @@ public class Property implements Externalizable {
      * The constructor.
      *
      * @param name The name
-     * @param text The text
+     * @param value The value
      */
-    public Property(String name, String text) {
+    public Property(String name, String value) {
         this.name = name;
-        this.text = text;
+        this.value = value;
     }
 
     /**
@@ -64,17 +75,60 @@ public class Property implements Externalizable {
     }
 
     /**
-     * @return the text
+     * @return the value
      */
-    public String getText() {
-        return text;
+    public String getValue() {
+        return value;
     }
 
     /**
-     * @param text the text to set
+     * @param value the value to set
      */
-    public void setText(String text) {
-        this.text = text;
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return the type
+     */
+    public PropertyType getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(PropertyType type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the number
+     */
+    public Double getNumber() {
+        if (number == null && value != null && type == PropertyType.Number) {
+            try {
+                return Double.valueOf(value);
+            } catch (Exception e) {
+                // Ignore
+            }
+        }
+        return number;
+    }
+
+    /**
+     * @param number the number to set
+     */
+    public void setNumber(Double number) {
+        this.number = number;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Property [name=" + name + ", value=" + value + ", type=" + type + ", number=" + number + "]";
     }
 
     /* (non-Javadoc)
@@ -85,7 +139,8 @@ public class Property implements Externalizable {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((text == null) ? 0 : text.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
     }
 
@@ -106,20 +161,14 @@ public class Property implements Externalizable {
                 return false;
         } else if (!name.equals(other.name))
             return false;
-        if (text == null) {
-            if (other.text != null)
+        if (type != other.type)
+            return false;
+        if (value == null) {
+            if (other.value != null)
                 return false;
-        } else if (!text.equals(other.text))
+        } else if (!value.equals(other.value))
             return false;
         return true;
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "Property [name=" + name + ", text=" + text + "]";
     }
 
     /* (non-Javadoc)
@@ -130,7 +179,9 @@ public class Property implements Externalizable {
         ois.readInt(); // Read version
 
         name = ois.readUTF();
-        text = ois.readUTF();
+        value = ois.readUTF();
+        type = PropertyType.values()[ois.readInt()];
+        number = ois.readDouble();
     }
 
     /* (non-Javadoc)
@@ -141,7 +192,9 @@ public class Property implements Externalizable {
         oos.writeInt(1); // Write version
 
         oos.writeUTF(name);
-        oos.writeUTF(text);
+        oos.writeUTF(value);
+        oos.writeInt(type.ordinal());
+        oos.writeDouble(number);
     }
 
 }

--- a/api/src/main/java/org/hawkular/apm/api/model/PropertyType.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/PropertyType.java
@@ -17,25 +17,20 @@
 package org.hawkular.apm.api.model;
 
 /**
- * This enumerated value represents a severity.
+ * This enumerated value represents a property type.
  *
  * @author gbrown
  */
-public enum Severity {
+public enum PropertyType {
 
     /**
-     * This represents an error.
+     * This represents a text value.
      */
-    Error,
+    Text,
 
     /**
-     * This represents a warning.
+     * This represents a numeric value.
      */
-    Warning,
-
-    /**
-     * This represents information.
-     */
-    Info
+    Number
 
 }

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/EvaluateURIActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/EvaluateURIActionHandlerTest.java
@@ -79,8 +79,8 @@ public class EvaluateURIActionHandlerTest {
         assertEquals(action.getTemplate(), consumer.getUri());
         assertTrue(trace.hasProperty("name"));
         assertTrue(trace.hasProperty("num"));
-        assertEquals("fred", trace.getProperties("name").iterator().next().getText());
-        assertEquals("5", trace.getProperties("num").iterator().next().getText());
+        assertEquals("fred", trace.getProperties("name").iterator().next().getValue());
+        assertEquals("5", trace.getProperties("num").iterator().next().getValue());
 
         assertNull(handler.getIssues());
     }
@@ -103,8 +103,8 @@ public class EvaluateURIActionHandlerTest {
 
         assertTrue(trace.hasProperty("name"));
         assertTrue(trace.hasProperty("num"));
-        assertEquals("hello world", trace.getProperties("name").iterator().next().getText());
-        assertEquals("5", trace.getProperties("num").iterator().next().getText());
+        assertEquals("hello world", trace.getProperties("name").iterator().next().getValue());
+        assertEquals("5", trace.getProperties("num").iterator().next().getValue());
 
         assertFalse(trace.hasProperty("another"));
 
@@ -131,9 +131,9 @@ public class EvaluateURIActionHandlerTest {
         assertTrue(trace.hasProperty("pathParam"));
         assertTrue(trace.hasProperty("name"));
         assertTrue(trace.hasProperty("num"));
-        assertEquals("test param", trace.getProperties("pathParam").iterator().next().getText());
-        assertEquals("hello world", trace.getProperties("name").iterator().next().getText());
-        assertEquals("5", trace.getProperties("num").iterator().next().getText());
+        assertEquals("test param", trace.getProperties("pathParam").iterator().next().getValue());
+        assertEquals("hello world", trace.getProperties("name").iterator().next().getValue());
+        assertEquals("5", trace.getProperties("num").iterator().next().getValue());
 
         assertFalse(trace.hasProperty("another"));
 

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/SetPropertyActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/SetPropertyActionHandlerTest.java
@@ -58,7 +58,7 @@ public class SetPropertyActionHandlerTest {
 
         assertEquals(1, trace.getProperties().size());
         assertTrue(trace.hasProperty(TEST_NAME_1));
-        assertEquals(TEST_VALUE_1, trace.getProperties(TEST_NAME_1).iterator().next().getText());
+        assertEquals(TEST_VALUE_1, trace.getProperties(TEST_NAME_1).iterator().next().getValue());
 
         assertNull(handler.getIssues());
     }

--- a/api/src/test/java/org/hawkular/apm/api/model/PropertyTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/model/PropertyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.apm.api.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author gbrown
+ */
+public class PropertyTest {
+
+    @Test
+    public void testJSONSerialisationNumber() {
+        String expected = "{\"name\":\"testprop\",\"value\":\"10.5\",\"type\":\"Number\",\"number\":10.5}";
+
+        Property property = new Property();
+        property.setName("testprop");
+        property.setValue("10.5");
+        property.setType(PropertyType.Number);
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            assertEquals(expected, mapper.writeValueAsString(property));
+        } catch (Exception e) {
+            fail("Failed to serialize: " + e);
+        }
+    }
+
+}

--- a/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/ProcessorManagerTest.java
+++ b/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/ProcessorManagerTest.java
@@ -432,7 +432,7 @@ public class ProcessorManagerTest {
 
         pm.process(trace, service, Direction.In, null, "first", "second");
 
-        assertEquals("second", trace.getProperties("test").iterator().next().getText());
+        assertEquals("second", trace.getProperties("test").iterator().next().getValue());
     }
 
     @Test

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearch.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearch.java
@@ -493,7 +493,7 @@ public class AnalyticsServiceElasticsearch extends AbstractAnalyticsService {
 
             TermsBuilder cardinalityBuilder = AggregationBuilders
                     .terms("cardinality")
-                    .field("properties.text")
+                    .field("properties.value")
                     .order(Order.aggregation("_count", false))
                     .size(criteria.getMaxResponseSize());
 

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchUtil.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchUtil.java
@@ -59,7 +59,7 @@ public class ElasticsearchUtil {
             for (PropertyCriteria pc : criteria.getProperties()) {
                 BoolQueryBuilder nestedQuery = QueryBuilders.boolQuery()
                         .must(QueryBuilders.matchQuery("properties.name", pc.getName()))
-                        .must(QueryBuilders.matchQuery("properties.text", pc.getValue()));
+                        .must(QueryBuilders.matchQuery("properties.value", pc.getValue()));
                 if (pc.isExcluded()) {
                     query = query.mustNot(QueryBuilders.nestedQuery("properties", nestedQuery));
                 } else {

--- a/server/elasticsearch/src/main/resources/hawkular-apm-mapping.json
+++ b/server/elasticsearch/src/main/resources/hawkular-apm-mapping.json
@@ -70,7 +70,7 @@
                             "type": "string",
                             "index": "not_analyzed"
                         },
-                        "text": {
+                        "value": {
                             "type": "string",
                             "index": "not_analyzed"
                         }
@@ -122,7 +122,7 @@
                             "type": "string",
                             "index": "not_analyzed"
                         },
-                        "text": {
+                        "value": {
                             "type": "string",
                             "index": "not_analyzed"
                         }
@@ -195,7 +195,7 @@
                             "type": "string",
                             "index": "not_analyzed"
                         },
-                        "text": {
+                        "value": {
                             "type": "string",
                             "index": "not_analyzed"
                         }
@@ -244,7 +244,7 @@
                             "type": "string",
                             "index": "not_analyzed"
                         },
-                        "text": {
+                        "value": {
                             "type": "string",
                             "index": "not_analyzed"
                         }
@@ -293,7 +293,7 @@
                             "type": "string",
                             "index": "not_analyzed"
                         },
-                        "text": {
+                        "value": {
                             "type": "string",
                             "index": "not_analyzed"
                         }


### PR DESCRIPTION
…c types. Also included deriving numeric values from the value string when type is Numeric - so properties only defined by name/value - but internally Elasticsearch can leverage the numeric representation for queries