### PR TITLE
Fixing squid:S2221 - "Exception" should not be caught when not required by called methods

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/helpers/XML.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/helpers/XML.java
@@ -28,10 +28,12 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.hawkular.apm.api.logging.Logger;
 import org.hawkular.apm.api.logging.Logger.Level;
+import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 
 /**
@@ -104,7 +106,7 @@ public class XML {
             if (result != null) {
                 return result;
             }
-        } catch (Exception e) {
+        } catch (XPathExpressionException e) {
             log.log(Level.SEVERE, "Failed to execute predicate xpath '" + xpath + "'", e);
         }
 
@@ -148,7 +150,7 @@ public class XML {
                 }
                 return serialize(result);
             }
-        } catch (Exception e) {
+        } catch (DOMException|XPathExpressionException e) {
             log.log(Level.SEVERE, "Failed to evaluate xpath '" + xpath + "'", e);
         }
 
@@ -275,7 +277,7 @@ public class XML {
             xpath = getExpression(xpath);
             XPath xp = XPathFactory.newInstance().newXPath();
             return (Node) xp.evaluate(xpath, domNode, XPathConstants.NODE);
-        } catch (Exception e) {
+        } catch (XPathExpressionException e) {
             log.log(Level.SEVERE, "Failed to select node for xpath '" + xpath + "'", e);
         }
 

--- a/api/src/main/java/org/hawkular/apm/api/model/Property.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/Property.java
@@ -122,7 +122,7 @@ public class Property implements Externalizable {
         if (number == null && value != null && type == PropertyType.Number) {
             try {
                 return Double.valueOf(value);
-            } catch (Exception e) {
+            } catch (NumberFormatException e) {
                 // Ignore
             }
         }

--- a/api/src/main/java/org/hawkular/apm/api/utils/PropertyUtil.java
+++ b/api/src/main/java/org/hawkular/apm/api/utils/PropertyUtil.java
@@ -101,7 +101,7 @@ public class PropertyUtil {
         if (value != null) {
             try {
                 return Integer.parseInt(value);
-            } catch (Exception e) {
+            } catch (NumberFormatException e) {
                 LOG.log(Level.WARNING, "Failed to convert property value '" + value + "' to integer", e);
             }
         }

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JavaxJmsHeadersAccessor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JavaxJmsHeadersAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.apm.instrumenter.headers;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class JavaxJmsHeadersAccessor implements HeadersAccessor {
                 try {
                     String value = (String) getHeaderMethod.invoke(target, key);
                     ret.put(key, value);
-                } catch (Exception e) {
+                } catch (IllegalAccessException|IllegalArgumentException|InvocationTargetException e) {
                     // Ignore property
                 }
             }

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchEmbeddedNode.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchEmbeddedNode.java
@@ -16,9 +16,7 @@
  */
 package org.hawkular.apm.server.elasticsearch;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.io.*;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -81,7 +79,7 @@ public final class ElasticsearchEmbeddedNode {
                 }
                 properties.load(stream);
                 stream.close();
-            } catch (Exception e) {
+            } catch (IOException e) {
                 log.log(Level.SEVERE, "Failed to load elasticsearch properties", e);
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2221 - ""Exception" should not be caught when not required by called methods".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S2221
Please let me know if you have any questions.
Artyom Melnikov