### PR TITLE
Fixing squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/services/AbstractConfigurationService.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/AbstractConfigurationService.java
@@ -93,8 +93,8 @@ public abstract class AbstractConfigurationService implements ConfigurationServi
             throws Exception {
         List<ConfigMessage> messages = new ArrayList<ConfigMessage>();
 
-        for (String name : configs.keySet()) {
-            messages.addAll(setBusinessTransaction(tenantId, name, configs.get(name)));
+        for (Map.Entry<String, BusinessTxnConfig> stringBusinessTxnConfigEntry : configs.entrySet()) {
+            messages.addAll(setBusinessTransaction(tenantId, stringBusinessTxnConfigEntry.getKey(), stringBusinessTxnConfigEntry.getValue()));
         }
 
         return messages;

--- a/client/analytics-service-rest-client/src/main/java/org/hawkular/apm/analytics/service/rest/client/AnalyticsServiceRESTClient.java
+++ b/client/analytics-service-rest-client/src/main/java/org/hawkular/apm/analytics/service/rest/client/AnalyticsServiceRESTClient.java
@@ -920,12 +920,12 @@ public class AnalyticsServiceRESTClient implements AnalyticsService {
             builder.append('?');
 
             boolean first = true;
-            for (String key : queryParams.keySet()) {
+            for (Map.Entry<String, String> stringStringEntry : queryParams.entrySet()) {
                 if (!first) {
                     builder.append('&');
                 }
-                String value = queryParams.get(key);
-                builder.append(key);
+                String value = stringStringEntry.getValue();
+                builder.append(stringStringEntry.getKey());
                 builder.append('=');
                 builder.append(value);
                 first = false;

--- a/client/collector/src/main/java/org/hawkular/apm/client/collector/DefaultTraceCollector.java
+++ b/client/collector/src/main/java/org/hawkular/apm/client/collector/DefaultTraceCollector.java
@@ -138,23 +138,23 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
                             Map<String, BusinessTxnConfig> changed = cs.getBusinessTransactions(null,
                                     configLastUpdated);
 
-                            for (String btxn : changed.keySet()) {
-                                BusinessTxnConfig btc = changed.get(btxn);
+                            for (Map.Entry<String, BusinessTxnConfig> stringBusinessTxnConfigEntry : changed.entrySet()) {
+                                BusinessTxnConfig btc = stringBusinessTxnConfigEntry.getValue();
 
                                 if (btc.isDeleted()) {
                                     if (log.isLoggable(Level.FINER)) {
-                                        log.finer("Removing config for btxn '" + btxn + "' = " + btc);
+                                        log.finer("Removing config for btxn '" + stringBusinessTxnConfigEntry.getKey() + "' = " + btc);
                                     }
 
-                                    filterManager.remove(btxn);
-                                    processorManager.remove(btxn);
+                                    filterManager.remove(stringBusinessTxnConfigEntry.getKey());
+                                    processorManager.remove(stringBusinessTxnConfigEntry.getKey());
                                 } else {
                                     if (log.isLoggable(Level.FINER)) {
-                                        log.finer("Changed config for btxn '" + btxn + "' = " + btc);
+                                        log.finer("Changed config for btxn '" + stringBusinessTxnConfigEntry.getKey() + "' = " + btc);
                                     }
 
-                                    filterManager.init(btxn, btc);
-                                    processorManager.init(btxn, btc);
+                                    filterManager.init(stringBusinessTxnConfigEntry.getKey(), btc);
+                                    processorManager.init(stringBusinessTxnConfigEntry.getKey(), btc);
                                 }
 
                                 if (btc.getLastUpdated() > configLastUpdated) {
@@ -1253,11 +1253,11 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
 
             if (headers != null && m.getHeaders().isEmpty()) {
                 // TODO: Need to have config to determine whether headers should be logged
-                for (String key : headers.keySet()) {
-                    String value = getHeaderValueText(headers.get(key));
+                for (Map.Entry<String, ?> stringEntry : headers.entrySet()) {
+                    String value = getHeaderValueText(stringEntry.getValue());
 
                     if (value != null) {
-                        m.getHeaders().put(key, value);
+                        m.getHeaders().put(stringEntry.getKey(), value);
                     }
                 }
             }

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/ClientManager.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/ClientManager.java
@@ -101,17 +101,17 @@ public class ClientManager {
         List<String> scriptNames = new ArrayList<String>();
         Map<String, Instrumentation> instrumentTypes=config.getInstrumentation();
 
-        for (String name : instrumentTypes.keySet()) {
-            Instrumentation types = instrumentTypes.get(name);
-            String rules = ruleTransformer.transform(name, types,
-                            config.getProperty("version."+name, null));
+        for (Map.Entry<String, Instrumentation> stringInstrumentationEntry : instrumentTypes.entrySet()) {
+            Instrumentation types = stringInstrumentationEntry.getValue();
+            String rules = ruleTransformer.transform(stringInstrumentationEntry.getKey(), types,
+                            config.getProperty("version."+ stringInstrumentationEntry.getKey(), null));
 
             if (log.isLoggable(Level.FINER)) {
-                log.finer("Update instrumentation script name=" + name + " rules=" + rules);
+                log.finer("Update instrumentation script name=" + stringInstrumentationEntry.getKey() + " rules=" + rules);
             }
 
             if (rules != null) {
-                scriptNames.add(name);
+                scriptNames.add(stringInstrumentationEntry.getKey());
                 scripts.add(rules);
             }
         }

--- a/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
+++ b/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
@@ -182,12 +182,12 @@ public class TraceServiceRESTClient extends TracePublisherRESTClient
             builder.append('?');
 
             boolean first = true;
-            for (String key : queryParams.keySet()) {
+            for (Map.Entry<String, String> stringStringEntry : queryParams.entrySet()) {
                 if (!first) {
                     builder.append('&');
                 }
-                String value = queryParams.get(key);
-                builder.append(key);
+                String value = stringStringEntry.getValue();
+                builder.append(stringStringEntry.getKey());
                 builder.append('=');
                 builder.append(value);
                 first = false;

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchClient.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchClient.java
@@ -241,19 +241,19 @@ public class ElasticsearchClient {
     private boolean prepareMapping(String index, Map<String, Object> defaultMappings) {
         boolean success = true;
 
-        for (String type : defaultMappings.keySet()) {
-            Map<String, Object> mapping = (Map<String, Object>) defaultMappings.get(type);
+        for (Map.Entry<String, Object> stringObjectEntry : defaultMappings.entrySet()) {
+            Map<String, Object> mapping = (Map<String, Object>) stringObjectEntry.getValue();
             if (mapping == null) {
                 throw new RuntimeException("type mapping not defined");
             }
             PutMappingRequestBuilder putMappingRequestBuilder = client.admin().indices().preparePutMapping()
                     .setIndices(index);
-            putMappingRequestBuilder.setType(type);
+            putMappingRequestBuilder.setType(stringObjectEntry.getKey());
             putMappingRequestBuilder.setSource(mapping);
 
             if (log.isLoggable(Level.FINE)) {
                 log.fine("Elasticsearch create mapping for index '"
-                        + index + " and type '" + type + "': " + mapping);
+                        + index + " and type '" + stringObjectEntry.getKey() + "': " + mapping);
             }
 
             PutMappingResponse resp = putMappingRequestBuilder.execute().actionGet();
@@ -261,12 +261,12 @@ public class ElasticsearchClient {
             if (resp.isAcknowledged()) {
                 if (log.isLoggable(Level.FINE)) {
                     log.fine("Elasticsearch mapping for index '"
-                            + index + " and type '" + type + "' was acknowledged");
+                            + index + " and type '" + stringObjectEntry.getKey() + "' was acknowledged");
                 }
             } else {
                 success = false;
                 log.warning("Elasticsearch mapping creation was not acknowledged for index '"
-                        + index + " and type '" + type + "'");
+                        + index + " and type '" + stringObjectEntry.getKey() + "'");
             }
         }
 

--- a/tools/instrumenter/src/main/java/org/hawkular/apm/tools/instrumenter/InstrumenterUtil.java
+++ b/tools/instrumenter/src/main/java/org/hawkular/apm/tools/instrumenter/InstrumenterUtil.java
@@ -129,13 +129,13 @@ public class InstrumenterUtil {
         List<String> scriptNames = new ArrayList<String>();
         Map<String, Instrumentation> instrumentTypes = config.getInstrumentation();
 
-        for (String name : instrumentTypes.keySet()) {
-            Instrumentation types = instrumentTypes.get(name);
-            String rules = ruleTransformer.transform(name, types,
-                    config.getProperty("version." + name, null));
+        for (Map.Entry<String, Instrumentation> stringInstrumentationEntry : instrumentTypes.entrySet()) {
+            Instrumentation types = stringInstrumentationEntry.getValue();
+            String rules = ruleTransformer.transform(stringInstrumentationEntry.getKey(), types,
+                    config.getProperty("version." + stringInstrumentationEntry.getKey(), null));
 
             if (rules != null) {
-                scriptNames.add(name);
+                scriptNames.add(stringInstrumentationEntry.getKey());
                 scripts.add(rules);
             }
         }
@@ -145,15 +145,15 @@ public class InstrumenterUtil {
 
             Transformer transformer = new Transformer(null, moduleSystem, scriptNames, scripts, false);
 
-            for (ArchivePath path : content.keySet()) {
-                Node node = content.get(path);
+            for (Map.Entry<ArchivePath, Node> archivePathNodeEntry : content.entrySet()) {
+                Node node = archivePathNodeEntry.getValue();
 
                 InputStream is = node.getAsset().openStream();
                 byte[] cls = new byte[is.available()];
                 is.read(cls);
                 is.close();
 
-                String clsName = path.get();
+                String clsName = archivePathNodeEntry.getKey().get();
                 clsName = clsName.replace(java.io.File.separatorChar, '.').substring(1, clsName.length() - 6);
 
                 if (log.isLoggable(Level.FINEST)) {
@@ -167,7 +167,7 @@ public class InstrumenterUtil {
                         log.finest("Instrumented class '" + clsName + "' length=" + newcls.length);
                     }
 
-                    archive.delete(path);
+                    archive.delete(archivePathNodeEntry.getKey());
 
                     Asset asset = new Asset() {
                         @Override
@@ -175,7 +175,7 @@ public class InstrumenterUtil {
                             return new ByteArrayInputStream(newcls);
                         }
                     };
-                    archive.add(asset, path);
+                    archive.add(asset, archivePathNodeEntry.getKey());
 
                     modified = true;
                 }
@@ -223,8 +223,8 @@ public class InstrumenterUtil {
 
             });
 
-            for (ArchivePath path : content.keySet()) {
-                Node node = content.get(path);
+            for (Map.Entry<ArchivePath, Node> archivePathNodeEntry : content.entrySet()) {
+                Node node = archivePathNodeEntry.getValue();
 
                 try (InputStream is = node.getAsset().openStream()) {
                     CollectorConfiguration subconfig = mapper.readValue(is, CollectorConfiguration.class);
@@ -251,13 +251,13 @@ public class InstrumenterUtil {
 
         Map<String, Instrumentation> instrumentTypes = config.getInstrumentation();
 
-        for (String name : instrumentTypes.keySet()) {
-            Instrumentation types = instrumentTypes.get(name);
-            String rules = ruleTransformer.transform(name, types,
-                    config.getProperty("version." + name, null));
+        for (Map.Entry<String, Instrumentation> stringInstrumentationEntry : instrumentTypes.entrySet()) {
+            Instrumentation types = stringInstrumentationEntry.getValue();
+            String rules = ruleTransformer.transform(stringInstrumentationEntry.getKey(), types,
+                    config.getProperty("version." + stringInstrumentationEntry.getKey(), null));
 
             if (rules != null) {
-                ruleCheck.addRule(name, rules);
+                ruleCheck.addRule(stringInstrumentationEntry.getKey(), rules);
             }
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - ""entrySet()" should be iterated when both the key and value are needed".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S2864
Please let me know if you have any questions.
Artyom Melnikov