### PR TITLE
Temporary fix for missing templates.js exception

### DIFF
--- a/ui/src/main/scripts/plugins/templates.js
+++ b/ui/src/main/scripts/plugins/templates.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+


### PR DESCRIPTION
@ammendonca Thanks Alex for finding the problem and solution.

Issue reported here: https://github.com/tracker1/gulp-header/issues/37

[INFO] [12:10:49] Starting 'template'...
[ERROR] fs.js:839
[ERROR]   return binding.lstat(pathModule._makeLong(path));
[ERROR]                  ^
[ERROR] 
[ERROR] Error: ENOENT: no such file or directory, lstat '/home/gbrown/repositories/hawkular/objectiser/hawkular-apm/ui/target/gulp-build/plugins/templates.js'
[ERROR]     at Error (native)
[ERROR]     at Object.fs.lstatSync (fs.js:839:18)

