### PR TITLE
Fixing squid:S2095, squid:S2674

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/services/ConfigurationLoader.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/ConfigurationLoader.java
@@ -177,10 +177,8 @@ public class ConfigurationLoader {
                 ret = ret.resolve(name);
 
                 if (name.endsWith(".jar") || name.endsWith(".war")) {
-                    try {
-                        FileSystem jarfs = FileSystems.newFileSystem(ret,
-                                Thread.currentThread().getContextClassLoader());
-
+                    try (FileSystem jarfs = FileSystems.newFileSystem(ret,
+                            Thread.currentThread().getContextClassLoader())) {
                         ret = jarfs.getRootDirectories().iterator().next();
                     } catch (IOException e) {
                         log.log(Level.SEVERE, "Failed to access archive '" + name + "'", e);

--- a/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
+++ b/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
@@ -79,7 +79,10 @@ public class TraceServiceRESTClient extends TracePublisherRESTClient
 
             byte[] b = new byte[is.available()];
 
-            is.read(b);
+            int count = is.read(b);
+            if (count != b.length) {
+                log.warning("Incomplete data read");
+            }
 
             is.close();
 

--- a/tools/instrumenter/src/main/java/org/hawkular/apm/tools/instrumenter/InstrumenterUtil.java
+++ b/tools/instrumenter/src/main/java/org/hawkular/apm/tools/instrumenter/InstrumenterUtil.java
@@ -150,7 +150,10 @@ public class InstrumenterUtil {
 
                 InputStream is = node.getAsset().openStream();
                 byte[] cls = new byte[is.available()];
-                is.read(cls);
+                int count = is.read(cls);
+                if (count != cls.length) {
+                    log.warning("Incomplete data read");
+                }
                 is.close();
 
                 String clsName = path.get();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S2095 - "Resources should be closed".
You can find more information about the issue here:
https://sonarqube.com/coding_rules#q=squid:S2095
squid:S2674 - "The value returned from a stream read should be checked".
You can find more information about the issue here:
https://sonarqube.com/coding_rules#q=squid:S2674
Please let me know if you have any questions.
Artyom Melnikov