### PR TITLE
Fixing squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/helpers/XML.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/helpers/XML.java
@@ -163,7 +163,7 @@ public class XML {
      * @return
      */
     protected static String getExpression(String expr) {
-        StringBuffer buf=new StringBuffer(expr);
+        StringBuilder buf=new StringBuilder(expr);
         int startIndex=-1;
         do {
             startIndex=buf.indexOf("*:");

--- a/api/src/main/java/org/hawkular/apm/api/services/AbstractAnalyticsService.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/AbstractAnalyticsService.java
@@ -531,7 +531,7 @@ public abstract class AbstractAnalyticsService implements AnalyticsService {
      * @return The regular expression
      */
     protected static String createRegex(String endpoint, boolean meta) {
-        StringBuffer regex = new StringBuffer();
+        StringBuilder regex = new StringBuilder();
 
         regex.append('^');
 

--- a/api/src/main/java/org/hawkular/apm/api/utils/EndpointUtil.java
+++ b/api/src/main/java/org/hawkular/apm/api/utils/EndpointUtil.java
@@ -32,7 +32,7 @@ public class EndpointUtil {
      * @return The endpoint descriptor
      */
     public static String encodeEndpoint(String uri, String operation) {
-        StringBuffer buf=new StringBuffer(uri);
+        StringBuilder buf=new StringBuilder(uri);
         if (operation != null && operation.trim().length() > 0) {
             buf.append('[');
             buf.append(operation);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1149 - "Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1149
Please let me know if you have any questions.
Artyom Melnikov