### PR TITLE
HWKAPM-485 Use a typed exception for triggering retries

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/services/AnalyticsService.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/AnalyticsService.java
@@ -190,42 +190,6 @@ public interface AnalyticsService {
                                 Criteria criteria, boolean asTree);
 
     /**
-     * This method stores the supplied list of node details.
-     *
-     * @param tenantId The tenant id
-     * @param nodeDetails The node details
-     * @throws Exception Failed to store
-     */
-    void storeNodeDetails(String tenantId, List<NodeDetails> nodeDetails) throws Exception;
-
-    /**
-     * This method stores the supplied list of communication details.
-     *
-     * @param tenantId The tenant id
-     * @param communicationDetails The communication details
-     * @throws Exception Failed to store
-     */
-    void storeCommunicationDetails(String tenantId, List<CommunicationDetails> communicationDetails) throws Exception;
-
-    /**
-     * This method stores the supplied list of completion times for end to end traces.
-     *
-     * @param tenantId The tenant id
-     * @param completionTimes The completion times
-     * @throws Exception Failed to store
-     */
-    void storeTraceCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws Exception;
-
-    /**
-     * This method stores the supplied list of completion times for individual fragments.
-     *
-     * @param tenantId The tenant id
-     * @param completionTimes The completion times
-     * @throws Exception Failed to store
-     */
-    void storeFragmentCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws Exception;
-
-    /**
      * This method returns the list of host names where activities were executed, subject to the supplied
      * criteria.
      *
@@ -234,6 +198,43 @@ public interface AnalyticsService {
      * @return The list of host names
      */
     List<String> getHostNames(String tenantId, Criteria criteria);
+
+    /**
+     * This method stores the supplied list of node details.
+     *
+     * @param tenantId The tenant id
+     * @param nodeDetails The node details
+     * @throws StoreException Failed to store
+     */
+    void storeNodeDetails(String tenantId, List<NodeDetails> nodeDetails) throws StoreException;
+
+    /**
+     * This method stores the supplied list of communication details.
+     *
+     * @param tenantId The tenant id
+     * @param communicationDetails The communication details
+     * @throws StoreException Failed to store
+     */
+    void storeCommunicationDetails(String tenantId, List<CommunicationDetails> communicationDetails)
+            throws StoreException;
+
+    /**
+     * This method stores the supplied list of completion times for end to end traces.
+     *
+     * @param tenantId The tenant id
+     * @param completionTimes The completion times
+     * @throws StoreException Failed to store
+     */
+    void storeTraceCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws StoreException;
+
+    /**
+     * This method stores the supplied list of completion times for individual fragments.
+     *
+     * @param tenantId The tenant id
+     * @param completionTimes The completion times
+     * @throws StoreException Failed to store
+     */
+    void storeFragmentCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws StoreException;
 
     /**
      * This method clears the analytics data for the specified tenant.

--- a/api/src/main/java/org/hawkular/apm/api/services/StoreException.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/StoreException.java
@@ -14,25 +14,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.apm.server.elasticsearch;
+package org.hawkular.apm.api.services;
 
 /**
- * This class is an exception representing Elasticsearch failures.
+ * This exception indicates a failure to store information.
  *
  * @author gbrown
  */
-public class ElasticsearchFailures extends Exception {
+public class StoreException extends Exception {
 
     /**  */
-    private static final long serialVersionUID = -5863892714328876036L;
+    private static final long serialVersionUID = -2673182772454488068L;
 
     /**
      * This constructor initialises the exception message.
      *
-     * @param mesg The elasticsearch failure message
+     * @param mesg The message
      */
-    public ElasticsearchFailures(String mesg) {
+    public StoreException(String mesg) {
         super(mesg);
+    }
+
+    /**
+     * This constructor initialises the associated exception.
+     *
+     * @param t The associated exception
+     */
+    public StoreException(Throwable t) {
+        super(t);
+    }
+
+    /**
+     * This constructor initialises the exception message.
+     *
+     * @param mesg The message
+     * @param t The associated exception
+     */
+    public StoreException(String mesg, Throwable t) {
+        super(mesg, t);
     }
 
 }

--- a/api/src/main/java/org/hawkular/apm/api/services/TraceService.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/TraceService.java
@@ -52,9 +52,9 @@ public interface TraceService {
      *
      * @param tenantId The tenant id
      * @param traces The traces
-     * @throws Exception Failed to store
+     * @throws StoreException Failed to store
      */
-    void storeTraces(String tenantId, List<Trace> traces) throws Exception;
+    void storeTraces(String tenantId, List<Trace> traces) throws StoreException;
 
     /**
      * This method clears the trace data for the supplied tenant.

--- a/client/analytics-service-rest-client/src/main/java/org/hawkular/apm/analytics/service/rest/client/AnalyticsServiceRESTClient.java
+++ b/client/analytics-service-rest-client/src/main/java/org/hawkular/apm/analytics/service/rest/client/AnalyticsServiceRESTClient.java
@@ -39,6 +39,7 @@ import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.api.model.events.NodeDetails;
 import org.hawkular.apm.api.services.AnalyticsService;
 import org.hawkular.apm.api.services.Criteria;
+import org.hawkular.apm.api.services.StoreException;
 import org.hawkular.apm.api.utils.PropertyUtil;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -1208,7 +1209,7 @@ public class AnalyticsServiceRESTClient implements AnalyticsService {
      */
     @Override
     public void storeCommunicationDetails(String tenantId, List<CommunicationDetails> communicationDetails)
-            throws Exception {
+            throws StoreException {
         throw new UnsupportedOperationException();
     }
 
@@ -1216,7 +1217,7 @@ public class AnalyticsServiceRESTClient implements AnalyticsService {
      * @see org.hawkular.apm.api.services.AnalyticsService#storeNodeDetails(java.lang.String, java.util.List)
      */
     @Override
-    public void storeNodeDetails(String tenantId, List<NodeDetails> nodeDetails) throws Exception {
+    public void storeNodeDetails(String tenantId, List<NodeDetails> nodeDetails) throws StoreException {
         throw new UnsupportedOperationException();
     }
 
@@ -1224,7 +1225,7 @@ public class AnalyticsServiceRESTClient implements AnalyticsService {
      * @see org.hawkular.apm.api.services.AnalyticsService#storeCompletionTimes(java.lang.String, java.util.List)
      */
     @Override
-    public void storeTraceCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws Exception {
+    public void storeTraceCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws StoreException {
         throw new UnsupportedOperationException();
     }
 
@@ -1233,7 +1234,7 @@ public class AnalyticsServiceRESTClient implements AnalyticsService {
      *                      java.util.List)
      */
     @Override
-    public void storeFragmentCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws Exception {
+    public void storeFragmentCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws StoreException {
         throw new UnsupportedOperationException();
     }
 

--- a/client/collector/src/test/java/org/hawkular/apm/client/collector/DefaultTraceCollectorTest.java
+++ b/client/collector/src/test/java/org/hawkular/apm/client/collector/DefaultTraceCollectorTest.java
@@ -43,6 +43,7 @@ import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.ConfigurationService;
 import org.hawkular.apm.api.services.Criteria;
 import org.hawkular.apm.api.services.PublisherMetricHandler;
+import org.hawkular.apm.api.services.StoreException;
 import org.hawkular.apm.api.services.TracePublisher;
 import org.hawkular.apm.api.services.TraceService;
 import org.hawkular.apm.client.collector.internal.FragmentBuilder;
@@ -1192,7 +1193,7 @@ public class DefaultTraceCollectorTest {
          */
         @Override
         public void storeTraces(String tenantId, List<Trace> businessTransactions)
-                throws Exception {
+                throws StoreException {
         }
 
         /* (non-Javadoc)

--- a/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
+++ b/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
@@ -27,6 +27,7 @@ import org.hawkular.apm.api.logging.Logger;
 import org.hawkular.apm.api.logging.Logger.Level;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.Criteria;
+import org.hawkular.apm.api.services.StoreException;
 import org.hawkular.apm.api.services.TracePublisher;
 import org.hawkular.apm.api.services.TraceService;
 import org.hawkular.apm.trace.publisher.rest.client.TracePublisherRESTClient;
@@ -206,7 +207,7 @@ public class TraceServiceRESTClient extends TracePublisherRESTClient
      */
     @Override
     public void storeTraces(String tenantId, List<Trace> traces)
-            throws Exception {
+            throws StoreException {
         throw new UnsupportedOperationException();
     }
 

--- a/processors/communicationdetails-deriver/src/main/java/org/hawkular/apm/processor/communicationdetails/CommunicationDetailsDeriver.java
+++ b/processors/communicationdetails-deriver/src/main/java/org/hawkular/apm/processor/communicationdetails/CommunicationDetailsDeriver.java
@@ -34,6 +34,7 @@ import org.hawkular.apm.api.model.trace.Producer;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.utils.EndpointUtil;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 /**
  * This class represents the communication details deriver.
@@ -91,7 +92,7 @@ public class CommunicationDetailsDeriver extends AbstractProcessor<Trace, Commun
      * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
      */
     @Override
-    public CommunicationDetails processOneToOne(String tenantId, Trace item) throws Exception {
+    public CommunicationDetails processOneToOne(String tenantId, Trace item) throws RetryAttemptException {
         CommunicationDetails ret = null;
 
         if (log.isLoggable(Level.FINEST)) {
@@ -169,7 +170,7 @@ public class CommunicationDetailsDeriver extends AbstractProcessor<Trace, Commun
                     }
 
                     // Need to retry, as the producer information is not currently available
-                    throw new RuntimeException("Producer information not available [last id checked = "
+                    throw new RetryAttemptException("Producer information not available [last id checked = "
                                             + lastId + "]");
                 }
             }
@@ -214,21 +215,6 @@ public class CommunicationDetailsDeriver extends AbstractProcessor<Trace, Commun
                 initialiseOutbound(((ContainerNode) n).getNodes(), baseTime, cd);
             }
         }
-    }
-
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processMultiple(java.lang.Object)
-     */
-    @Override
-    public List<CommunicationDetails> processOneToMany(String tenantId, Trace item) throws Exception {
-        return null;
-    }
-
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#cleanup(java.util.List)
-     */
-    @Override
-    public void cleanup(String tenantId, List<Trace> items) {
     }
 
 }

--- a/processors/fragmentcompletiontime-deriver/src/main/java/org/hawkular/apm/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
+++ b/processors/fragmentcompletiontime-deriver/src/main/java/org/hawkular/apm/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.apm.processor.fragmentcompletiontime;
 
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,6 +24,7 @@ import org.hawkular.apm.api.model.trace.Consumer;
 import org.hawkular.apm.api.model.trace.Node;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 /**
  * This class represents the fragment completion time deriver.
@@ -46,7 +46,7 @@ public class FragmentCompletionTimeDeriver extends AbstractProcessor<Trace, Comp
      * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
      */
     @Override
-    public CompletionTime processOneToOne(String tenantId, Trace item) throws Exception {
+    public CompletionTime processOneToOne(String tenantId, Trace item) throws RetryAttemptException {
         // Check fragment has top level node
         if (!item.getNodes().isEmpty()) {
             Node n = item.getNodes().get(0);
@@ -78,11 +78,4 @@ public class FragmentCompletionTimeDeriver extends AbstractProcessor<Trace, Comp
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processMultiple(java.lang.Object)
-     */
-    @Override
-    public List<CompletionTime> processOneToMany(String tenantId, Trace item) throws Exception {
-        return null;
-    }
 }

--- a/processors/nodedetails-deriver/src/main/java/org/hawkular/apm/processor/nodedetails/NodeDetailsDeriver.java
+++ b/processors/nodedetails-deriver/src/main/java/org/hawkular/apm/processor/nodedetails/NodeDetailsDeriver.java
@@ -32,6 +32,7 @@ import org.hawkular.apm.api.model.trace.NodeType;
 import org.hawkular.apm.api.model.trace.Producer;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 /**
  * This class represents the node details deriver.
@@ -50,18 +51,10 @@ public class NodeDetailsDeriver extends AbstractProcessor<Trace, NodeDetails> {
     }
 
     /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
-     */
-    @Override
-    public NodeDetails processOneToOne(String tenantId, Trace item) throws Exception {
-        return null;
-    }
-
-    /* (non-Javadoc)
      * @see org.hawkular.apm.server.api.task.Processor#processMultiple(java.lang.Object)
      */
     @Override
-    public List<NodeDetails> processOneToMany(String tenantId, Trace item) throws Exception {
+    public List<NodeDetails> processOneToMany(String tenantId, Trace item) throws RetryAttemptException {
         List<NodeDetails> ret = new ArrayList<NodeDetails>();
 
         long baseTime = 0;

--- a/processors/notification-deriver/src/main/java/org/hawkular/apm/processor/notification/NotificationDeriver.java
+++ b/processors/notification-deriver/src/main/java/org/hawkular/apm/processor/notification/NotificationDeriver.java
@@ -25,6 +25,7 @@ import org.hawkular.apm.api.model.trace.ContainerNode;
 import org.hawkular.apm.api.model.trace.Node;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 /**
  * This class represents the notification deriver.
@@ -46,7 +47,7 @@ public class NotificationDeriver extends AbstractProcessor<Trace, Notification> 
      * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
      */
     @Override
-    public Notification processOneToOne(String tenantId, Trace item) throws Exception {
+    public Notification processOneToOne(String tenantId, Trace item) throws RetryAttemptException {
         // Check if named txn and has nodes
         if (item.getBusinessTransaction() != null && !item.getBusinessTransaction().trim().isEmpty()
                 && !item.getNodes().isEmpty()) {
@@ -91,11 +92,4 @@ public class NotificationDeriver extends AbstractProcessor<Trace, Notification> 
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processMultiple(java.lang.Object)
-     */
-    @Override
-    public List<Notification> processOneToMany(String tenantId, Trace item) throws Exception {
-        return null;
-    }
 }

--- a/processors/tracecompletiontime-deriver/src/main/java/org/hawkular/apm/processor/tracecompletiontime/TraceCompletionInformationInitiator.java
+++ b/processors/tracecompletiontime-deriver/src/main/java/org/hawkular/apm/processor/tracecompletiontime/TraceCompletionInformationInitiator.java
@@ -26,6 +26,7 @@ import org.hawkular.apm.api.model.trace.CorrelationIdentifier.Scope;
 import org.hawkular.apm.api.model.trace.Node;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 /**
  * This class represents the function for initiating completion time calculation based on
@@ -50,7 +51,7 @@ public class TraceCompletionInformationInitiator extends
      */
     @Override
     public TraceCompletionInformation processOneToOne(String tenantId,
-            Trace item) throws Exception {
+            Trace item) throws RetryAttemptException {
         // Check whether the trace fragment is an initial fragment
         if (!item.getNodes().isEmpty()) {
             Node n = item.getNodes().get(0);
@@ -100,7 +101,7 @@ public class TraceCompletionInformationInitiator extends
      */
     @Override
     public List<TraceCompletionInformation> processOneToMany(String tenantId,
-            Trace item) throws Exception {
+            Trace item) throws RetryAttemptException {
         return null;
     }
 }

--- a/processors/tracecompletiontime-deriver/src/main/java/org/hawkular/apm/processor/tracecompletiontime/TraceCompletionInformationProcessor.java
+++ b/processors/tracecompletiontime-deriver/src/main/java/org/hawkular/apm/processor/tracecompletiontime/TraceCompletionInformationProcessor.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import org.hawkular.apm.api.model.events.CommunicationDetails;
 import org.hawkular.apm.processor.tracecompletiontime.TraceCompletionInformation.Communication;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 /**
  * This class represents the function for processing completion information associated with
@@ -79,7 +80,7 @@ public class TraceCompletionInformationProcessor extends
      */
     @Override
     public TraceCompletionInformation processOneToOne(String tenantId,
-            TraceCompletionInformation item) throws Exception {
+            TraceCompletionInformation item) throws RetryAttemptException {
 
         if (!item.getCommunications().isEmpty()) {
             long currentTime = System.currentTimeMillis();
@@ -167,12 +168,4 @@ public class TraceCompletionInformationProcessor extends
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processMultiple(java.lang.String,java.lang.Object)
-     */
-    @Override
-    public List<TraceCompletionInformation> processOneToMany(String tenantId,
-            TraceCompletionInformation item) throws Exception {
-        return null;
-    }
 }

--- a/processors/tracecompletiontime-deriver/src/main/java/org/hawkular/apm/processor/tracecompletiontime/TraceCompletionTimeDeriver.java
+++ b/processors/tracecompletiontime-deriver/src/main/java/org/hawkular/apm/processor/tracecompletiontime/TraceCompletionTimeDeriver.java
@@ -16,12 +16,12 @@
  */
 package org.hawkular.apm.processor.tracecompletiontime;
 
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 /**
  * This class represents the end to end business transaction completion time deriver.
@@ -43,7 +43,8 @@ public class TraceCompletionTimeDeriver extends AbstractProcessor<TraceCompletio
      * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.String,java.lang.Object)
      */
     @Override
-    public CompletionTime processOneToOne(String tenantId, TraceCompletionInformation item) throws Exception {
+    public CompletionTime processOneToOne(String tenantId, TraceCompletionInformation item)
+            throws RetryAttemptException {
         // Check if named txn
         if (item.getCommunications().isEmpty()) {
 
@@ -56,11 +57,4 @@ public class TraceCompletionTimeDeriver extends AbstractProcessor<TraceCompletio
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processMultiple(java.lang.String,java.lang.Object)
-     */
-    @Override
-    public List<CompletionTime> processOneToMany(String tenantId, TraceCompletionInformation item) throws Exception {
-        return null;
-    }
 }

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/AbstractProcessor.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/AbstractProcessor.java
@@ -75,7 +75,7 @@ public abstract class AbstractProcessor<T, R> implements Processor<T,R> {
      * @see org.hawkular.apm.server.api.task.Processor#processOneToOne(java.lang.String, java.lang.Object)
      */
     @Override
-    public R processOneToOne(String tenantId, T item) throws Exception {
+    public R processOneToOne(String tenantId, T item) throws RetryAttemptException {
         return null;
     }
 
@@ -83,7 +83,7 @@ public abstract class AbstractProcessor<T, R> implements Processor<T,R> {
      * @see org.hawkular.apm.server.api.task.Processor#processOneToMany(java.lang.String, java.lang.Object)
      */
     @Override
-    public List<R> processOneToMany(String tenantId, T item) throws Exception {
+    public List<R> processOneToMany(String tenantId, T item) throws RetryAttemptException {
         return null;
     }
 
@@ -91,7 +91,7 @@ public abstract class AbstractProcessor<T, R> implements Processor<T,R> {
      * @see org.hawkular.apm.server.api.task.Processor#processManyToMany(java.lang.String, java.util.List)
      */
     @Override
-    public List<R> processManyToMany(String tenantId, List<T> items) throws Exception {
+    public List<R> processManyToMany(String tenantId, List<T> items) throws RetryAttemptException {
         return null;
     }
 

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/ProcessingUnit.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/ProcessingUnit.java
@@ -104,7 +104,7 @@ public class ProcessingUnit<T, R> implements Handler<T> {
     public void handle(String tenantId, List<T> items) throws Exception {
         List<R> results = null;
         List<T> retries = null;
-        Exception lastException = null;
+        RetryAttemptException lastException = null;
 
         processor.initialise(tenantId, items);
 
@@ -117,8 +117,9 @@ public class ProcessingUnit<T, R> implements Handler<T> {
         if (processor.getType() == ProcessorType.ManyToMany) {
             try {
                 results = processor.processManyToMany(tenantId, items);
-            } catch (Exception e) {
+            } catch (RetryAttemptException e) {
                 retries = items;
+                lastException = e;
             }
         } else {
             for (int i = 0; i < items.size(); i++) {
@@ -140,7 +141,7 @@ public class ProcessingUnit<T, R> implements Handler<T> {
                             results.add(result);
                         }
                     }
-                } catch (Exception e) {
+                } catch (RetryAttemptException e) {
                     if (retryHandler != null) {
                         if (retries == null) {
                             retries = new ArrayList<T>();

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/Processor.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/Processor.java
@@ -49,9 +49,9 @@ public interface Processor<T, R> {
      * @param tenantId The optional tenant id
      * @param item The item
      * @return The optional value
-     * @throws Exception Failed to process the item
+     * @throws RetryAttemptException Failed to process the item
      */
-    R processOneToOne(String tenantId, T item) throws Exception;
+    R processOneToOne(String tenantId, T item) throws RetryAttemptException;
 
     /**
      * This method processes the supplied item to
@@ -60,9 +60,9 @@ public interface Processor<T, R> {
      * @param tenantId The optional tenant id
      * @param item The item
      * @return The list of values
-     * @throws Exception Failed to process the item
+     * @throws RetryAttemptException Failed to process the item
      */
-    List<R> processOneToMany(String tenantId, T item) throws Exception;
+    List<R> processOneToMany(String tenantId, T item) throws RetryAttemptException;
 
     /**
      * This method processes the supplied items to
@@ -71,9 +71,9 @@ public interface Processor<T, R> {
      * @param tenantId The optional tenant id
      * @param items The items
      * @return The list of values
-     * @throws Exception Failed to process the item
+     * @throws RetryAttemptException Failed to process the item
      */
-    List<R> processManyToMany(String tenantId, List<T> items) throws Exception;
+    List<R> processManyToMany(String tenantId, List<T> items) throws RetryAttemptException;
 
     /**
      * This method determines the delivery delay (in milliseconds)

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/RetryAttemptException.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/RetryAttemptException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.apm.server.api.task;
+
+/**
+ * This exception class indicates that a failure occurred while processing one or
+ * more events, and therefore a retry should be performed.
+ *
+ * @author gbrown
+ */
+public class RetryAttemptException extends Exception {
+
+    /**  */
+    private static final long serialVersionUID = -9183048971847453822L;
+
+    /**
+     * This constructor initialises the message.
+     *
+     * @param mesg The message
+     */
+    public RetryAttemptException(String mesg) {
+        super(mesg);
+    }
+
+    /**
+     * This constructor initialises the associated exception.
+     *
+     * @param t The associated exception
+     */
+    public RetryAttemptException(Throwable t) {
+        super(t);
+    }
+
+    /**
+     * This constructor initialises the message and associated exception.
+     *
+     * @param mesg The message
+     * @param t The associated exception
+     */
+    public RetryAttemptException(String mesg, Throwable t) {
+        super(mesg, t);
+    }
+}

--- a/server/api/src/test/java/org/hawkular/apm/server/api/task/ProcessingUnitTest.java
+++ b/server/api/src/test/java/org/hawkular/apm/server/api/task/ProcessingUnitTest.java
@@ -37,7 +37,7 @@ public class ProcessingUnitTest {
         Processor<String, String> proc = new AbstractProcessor<String, String>(ProcessorType.OneToOne) {
 
             @Override
-            public String processOneToOne(String tenantId, String item) throws Exception {
+            public String processOneToOne(String tenantId, String item) throws RetryAttemptException {
                 return item;
             }
         };
@@ -73,8 +73,8 @@ public class ProcessingUnitTest {
         Processor<String, String> proc = new AbstractProcessor<String, String>(ProcessorType.OneToOne) {
 
             @Override
-            public String processOneToOne(String tenantId, String item) throws Exception {
-                throw new Exception("PLEASE RETRY");
+            public String processOneToOne(String tenantId, String item) throws RetryAttemptException {
+                throw new RetryAttemptException("PLEASE RETRY");
             }
         };
 
@@ -110,9 +110,9 @@ public class ProcessingUnitTest {
         Processor<String, String> proc = new AbstractProcessor<String, String>(ProcessorType.OneToOne) {
 
             @Override
-            public String processOneToOne(String tenantId, String item) throws Exception {
+            public String processOneToOne(String tenantId, String item) throws RetryAttemptException {
                 if (item.equals("world")) {
-                    throw new Exception("PLEASE RETRY");
+                    throw new RetryAttemptException("PLEASE RETRY");
                 }
                 return item;
             }
@@ -150,7 +150,7 @@ public class ProcessingUnitTest {
         Processor<String, String> proc = new AbstractProcessor<String, String>(ProcessorType.OneToMany) {
 
             @Override
-            public List<String> processOneToMany(String tenantId, String item) throws Exception {
+            public List<String> processOneToMany(String tenantId, String item) throws RetryAttemptException {
                 List<String> ret = new ArrayList<String>();
                 ret.add(item);
                 ret.add(item);
@@ -189,8 +189,8 @@ public class ProcessingUnitTest {
         Processor<String, String> proc = new AbstractProcessor<String, String>(ProcessorType.OneToMany) {
 
             @Override
-            public List<String> processOneToMany(String tenantId, String item) throws Exception {
-                throw new Exception("PLEASE RETRY");
+            public List<String> processOneToMany(String tenantId, String item) throws RetryAttemptException {
+                throw new RetryAttemptException("PLEASE RETRY");
             }
         };
 
@@ -226,9 +226,9 @@ public class ProcessingUnitTest {
         Processor<String, String> proc = new AbstractProcessor<String, String>(ProcessorType.OneToMany) {
 
             @Override
-            public List<String> processOneToMany(String tenantId, String item) throws Exception {
+            public List<String> processOneToMany(String tenantId, String item) throws RetryAttemptException {
                 if (item.equals("world")) {
-                    throw new Exception("PLEASE RETRY");
+                    throw new RetryAttemptException("PLEASE RETRY");
                 }
                 List<String> ret = new ArrayList<String>();
                 ret.add(item);

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearch.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearch.java
@@ -75,9 +75,11 @@ import org.hawkular.apm.api.model.events.NodeDetails;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.AbstractAnalyticsService;
 import org.hawkular.apm.api.services.Criteria;
+import org.hawkular.apm.api.services.StoreException;
 import org.hawkular.apm.api.utils.EndpointUtil;
 import org.hawkular.apmserver.elasticsearch.log.MsgLogger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -1014,164 +1016,6 @@ public class AnalyticsServiceElasticsearch extends AbstractAnalyticsService {
     }
 
     /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeCommunicationDetails(java.lang.String, java.util.List)
-     */
-    @Override
-    public void storeCommunicationDetails(String tenantId, List<CommunicationDetails> communicationDetails)
-            throws Exception {
-        client.initTenant(tenantId);
-
-        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
-
-        for (int i = 0; i < communicationDetails.size(); i++) {
-            CommunicationDetails cd = communicationDetails.get(i);
-            String json = mapper.writeValueAsString(cd);
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.tracef("Storing communication details: %s", json);
-            }
-
-            bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
-                    COMMUNICATION_DETAILS_TYPE, cd.getId()).setSource(json));
-        }
-
-        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
-
-        if (bulkItemResponses.hasFailures()) {
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Failed to store communication details to elasticsearch: "
-                        + bulkItemResponses.buildFailureMessage());
-            }
-
-            throw new ElasticsearchFailures(bulkItemResponses.buildFailureMessage());
-
-        } else {
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Success storing communication details to elasticsearch");
-            }
-        }
-    }
-
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeNodeDetails(java.lang.String, java.util.List)
-     */
-    @Override
-    public void storeNodeDetails(String tenantId, List<NodeDetails> nodeDetails) throws Exception {
-        client.initTenant(tenantId);
-
-        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
-
-        for (int i = 0; i < nodeDetails.size(); i++) {
-            NodeDetails rt = nodeDetails.get(i);
-            String json = mapper.writeValueAsString(rt);
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.tracef("Storing node details: %s", json);
-            }
-
-            bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
-                    NODE_DETAILS_TYPE, rt.getId()).setSource(json));
-        }
-
-        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
-
-        if (bulkItemResponses.hasFailures()) {
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Failed to store node details to elasticsearch: "
-                        + bulkItemResponses.buildFailureMessage());
-            }
-
-            throw new ElasticsearchFailures(bulkItemResponses.buildFailureMessage());
-
-        } else {
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Success storing node details to elasticsearch");
-            }
-        }
-    }
-
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeCompletionTimes(java.lang.String, java.util.List)
-     */
-    @Override
-    public void storeTraceCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws Exception {
-        client.initTenant(tenantId);
-
-        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
-
-        for (int i = 0; i < completionTimes.size(); i++) {
-            CompletionTime ct = completionTimes.get(i);
-            String json = mapper.writeValueAsString(ct);
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.tracef("Storing btxn completion time: %s", json);
-            }
-
-            bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
-                    TRACE_COMPLETION_TIME_TYPE, ct.getId()).setSource(json));
-        }
-
-        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
-
-        if (bulkItemResponses.hasFailures()) {
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Failed to store btxn completion times to elasticsearch: "
-                        + bulkItemResponses.buildFailureMessage());
-            }
-
-            throw new ElasticsearchFailures(bulkItemResponses.buildFailureMessage());
-
-        } else {
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Success storing btxn completion times to elasticsearch");
-            }
-        }
-    }
-
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeFragmentCompletionTimes(java.lang.String,
-     *                                      java.util.List)
-     */
-    @Override
-    public void storeFragmentCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws Exception {
-        client.initTenant(tenantId);
-
-        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
-
-        for (int i = 0; i < completionTimes.size(); i++) {
-            CompletionTime ct = completionTimes.get(i);
-            String json = mapper.writeValueAsString(ct);
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.tracef("Storing fragment completion time: %s", json);
-            }
-
-            bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
-                    FRAGMENT_COMPLETION_TIME_TYPE, ct.getId()).setSource(json));
-        }
-
-        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
-
-        if (bulkItemResponses.hasFailures()) {
-
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Failed to store fragment completion times to elasticsearch: "
-                        + bulkItemResponses.buildFailureMessage());
-            }
-
-            throw new ElasticsearchFailures(bulkItemResponses.buildFailureMessage());
-
-        } else {
-            if (msgLog.isTraceEnabled()) {
-                msgLog.trace("Success storing fragment completion times to elasticsearch");
-            }
-        }
-    }
-
-    /* (non-Javadoc)
      * @see org.hawkular.apm.api.services.AnalyticsService#getHostNames(java.lang.String,
      *                      org.hawkular.apm.api.services.BaseCriteria)
      */
@@ -1230,6 +1074,182 @@ public class AnalyticsServiceElasticsearch extends AbstractAnalyticsService {
         Collections.sort(ret);
 
         return ret;
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.apm.api.services.AnalyticsService#storeCommunicationDetails(java.lang.String, java.util.List)
+     */
+    @Override
+    public void storeCommunicationDetails(String tenantId, List<CommunicationDetails> communicationDetails)
+            throws StoreException {
+        client.initTenant(tenantId);
+
+        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
+
+        try {
+            for (int i = 0; i < communicationDetails.size(); i++) {
+                CommunicationDetails cd = communicationDetails.get(i);
+                String json = mapper.writeValueAsString(cd);
+
+                if (msgLog.isTraceEnabled()) {
+                    msgLog.tracef("Storing communication details: %s", json);
+                }
+
+                bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
+                        COMMUNICATION_DETAILS_TYPE, cd.getId()).setSource(json));
+            }
+        } catch (JsonProcessingException e) {
+            throw new StoreException(e);
+        }
+
+        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
+
+        if (bulkItemResponses.hasFailures()) {
+
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Failed to store communication details to elasticsearch: "
+                        + bulkItemResponses.buildFailureMessage());
+            }
+
+            throw new StoreException(bulkItemResponses.buildFailureMessage());
+
+        } else {
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Success storing communication details to elasticsearch");
+            }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.apm.api.services.AnalyticsService#storeNodeDetails(java.lang.String, java.util.List)
+     */
+    @Override
+    public void storeNodeDetails(String tenantId, List<NodeDetails> nodeDetails) throws StoreException {
+        client.initTenant(tenantId);
+
+        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
+
+        try {
+            for (int i = 0; i < nodeDetails.size(); i++) {
+                NodeDetails rt = nodeDetails.get(i);
+                String json = mapper.writeValueAsString(rt);
+
+                if (msgLog.isTraceEnabled()) {
+                    msgLog.tracef("Storing node details: %s", json);
+                }
+
+                bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
+                        NODE_DETAILS_TYPE, rt.getId()).setSource(json));
+            }
+        } catch (JsonProcessingException e) {
+            throw new StoreException(e);
+        }
+
+        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
+
+        if (bulkItemResponses.hasFailures()) {
+
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Failed to store node details to elasticsearch: "
+                        + bulkItemResponses.buildFailureMessage());
+            }
+
+            throw new StoreException(bulkItemResponses.buildFailureMessage());
+
+        } else {
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Success storing node details to elasticsearch");
+            }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.apm.api.services.AnalyticsService#storeCompletionTimes(java.lang.String, java.util.List)
+     */
+    @Override
+    public void storeTraceCompletionTimes(String tenantId, List<CompletionTime> completionTimes)
+            throws StoreException {
+        client.initTenant(tenantId);
+
+        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
+
+        try {
+            for (int i = 0; i < completionTimes.size(); i++) {
+                CompletionTime ct = completionTimes.get(i);
+                String json = mapper.writeValueAsString(ct);
+
+                if (msgLog.isTraceEnabled()) {
+                    msgLog.tracef("Storing btxn completion time: %s", json);
+                }
+
+                bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
+                        TRACE_COMPLETION_TIME_TYPE, ct.getId()).setSource(json));
+            }
+        } catch (JsonProcessingException e) {
+            throw new StoreException(e);
+        }
+
+        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
+
+        if (bulkItemResponses.hasFailures()) {
+
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Failed to store btxn completion times to elasticsearch: "
+                        + bulkItemResponses.buildFailureMessage());
+            }
+
+            throw new StoreException(bulkItemResponses.buildFailureMessage());
+
+        } else {
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Success storing btxn completion times to elasticsearch");
+            }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.apm.api.services.AnalyticsService#storeFragmentCompletionTimes(java.lang.String,
+     *                                      java.util.List)
+     */
+    @Override
+    public void storeFragmentCompletionTimes(String tenantId, List<CompletionTime> completionTimes)
+            throws StoreException {
+        client.initTenant(tenantId);
+
+        BulkRequestBuilder bulkRequestBuilder = client.getElasticsearchClient().prepareBulk();
+
+        try {
+            for (int i = 0; i < completionTimes.size(); i++) {
+                CompletionTime ct = completionTimes.get(i);
+                String json = mapper.writeValueAsString(ct);
+
+                if (msgLog.isTraceEnabled()) {
+                    msgLog.tracef("Storing fragment completion time: %s", json);
+                }
+
+                bulkRequestBuilder.add(client.getElasticsearchClient().prepareIndex(client.getIndex(tenantId),
+                        FRAGMENT_COMPLETION_TIME_TYPE, ct.getId()).setSource(json));
+            }
+        } catch (JsonProcessingException e) {
+            throw new StoreException(e);
+        }
+
+        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
+
+        if (bulkItemResponses.hasFailures()) {
+
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Failed to store fragment completion times to elasticsearch: "
+                        + bulkItemResponses.buildFailureMessage());
+            }
+
+            throw new StoreException(bulkItemResponses.buildFailureMessage());
+
+        } else {
+            if (msgLog.isTraceEnabled()) {
+                msgLog.trace("Success storing fragment completion times to elasticsearch");
+            }
+        }
     }
 
     /* (non-Javadoc)

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsCacheMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsCacheMDB.java
@@ -28,6 +28,7 @@ import org.hawkular.apm.api.model.events.CommunicationDetails;
 import org.hawkular.apm.processor.tracecompletiontime.CommunicationDetailsCache;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
 import org.hawkular.apm.server.api.task.Processor.ProcessorType;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -67,7 +68,8 @@ public class CommunicationDetailsCacheMDB extends RetryCapableMDB<CommunicationD
         setProcessor(new AbstractProcessor<CommunicationDetails,Void>(ProcessorType.ManyToMany) {
 
             @Override
-            public List<Void> processManyToMany(String tenantId, List<CommunicationDetails> items) throws Exception {
+            public List<Void> processManyToMany(String tenantId, List<CommunicationDetails> items)
+                    throws RetryAttemptException {
                 communicationDetailsCache.store(tenantId, items);
                 return null;
             }

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeStoreMDB.java
@@ -26,8 +26,10 @@ import javax.jms.MessageListener;
 
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.api.services.AnalyticsService;
+import org.hawkular.apm.api.services.StoreException;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
 import org.hawkular.apm.server.api.task.Processor.ProcessorType;
+import org.hawkular.apm.server.api.task.RetryAttemptException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -58,8 +60,13 @@ public class FragmentCompletionTimeStoreMDB extends RetryCapableMDB<CompletionTi
         setProcessor(new AbstractProcessor<CompletionTime, Void>(ProcessorType.ManyToMany) {
 
             @Override
-            public List<Void> processManyToMany(String tenantId, List<CompletionTime> items) throws Exception {
-                analyticsService.storeFragmentCompletionTimes(tenantId, items);
+            public List<Void> processManyToMany(String tenantId, List<CompletionTime> items)
+                    throws RetryAttemptException {
+                try {
+                    analyticsService.storeFragmentCompletionTimes(tenantId, items);
+                } catch (StoreException se) {
+                    throw new RetryAttemptException(se);
+                }
                 return null;
             }
         });


### PR DESCRIPTION
Review notes:
- Added typed exception for both the processor, to trigger the retry, but also on the TraceService and AnalyticsService APIs related to failures when storing information.
