### PR TITLE
HWKAPM-483 Fix JMS retry mechanism to avoid publishing retry messages…

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/services/Publisher.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/Publisher.java
@@ -53,6 +53,18 @@ public interface Publisher<T> {
     void publish(String tenantId, List<T> items, int retryCount, long delay) throws Exception;
 
     /**
+     * This method publishes the list of items.
+     *
+     * @param tenantId The tenant
+     * @param items The list of items
+     * @param subscriber The optional name of the subscriber requesting the retry
+     * @param retryCount The retry count
+     * @param delay The delay
+     * @throws Exception Failed to publish
+     */
+    void retry(String tenantId, List<T> items, String subscriber, int retryCount, long delay) throws Exception;
+
+    /**
      * This method sets the metric handler for the publisher.
      *
      * @param handler The handler

--- a/client/collector/src/test/java/org/hawkular/apm/client/collector/DefaultTraceCollectorTest.java
+++ b/client/collector/src/test/java/org/hawkular/apm/client/collector/DefaultTraceCollectorTest.java
@@ -1142,6 +1142,14 @@ public class DefaultTraceCollectorTest {
         }
 
         /* (non-Javadoc)
+         * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
+         */
+        @Override
+        public void retry(String tenantId, List<Trace> items, String subscriber, int retryCount, long delay)
+                throws Exception {
+        }
+
+        /* (non-Javadoc)
          * @see org.hawkular.apm.api.services.BusinessTransactionService#get(java.lang.String, java.lang.String)
          */
         @Override

--- a/client/trace-publisher-rest-client/src/main/java/org/hawkular/apm/trace/publisher/rest/client/TracePublisherRESTClient.java
+++ b/client/trace-publisher-rest-client/src/main/java/org/hawkular/apm/trace/publisher/rest/client/TracePublisherRESTClient.java
@@ -181,6 +181,15 @@ public class TracePublisherRESTClient implements TracePublisher {
         throw new java.lang.UnsupportedOperationException("Cannot set the retry count and delay");
     }
 
+    /* (non-Javadoc)
+     * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
+     */
+    @Override
+    public void retry(String tenantId, List<Trace> items, String subscriber, int retryCount, long delay)
+            throws Exception {
+        throw new java.lang.UnsupportedOperationException("Cannot retry");
+    }
+
     /**
      * Add the header values to the supplied connection.
      *

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/ProcessingUnit.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/ProcessingUnit.java
@@ -37,6 +37,7 @@ public class ProcessingUnit<T, R> implements Handler<T> {
     private Processor<T, R> processor;
 
     private int retryCount;
+    private String retrySubscriber;
 
     private Handler<R> resultHandler;
     private Handler<T> retryHandler;
@@ -67,6 +68,20 @@ public class ProcessingUnit<T, R> implements Handler<T> {
      */
     public void setRetryCount(int retryCount) {
         this.retryCount = retryCount;
+    }
+
+    /**
+     * @return the retrySubscriber
+     */
+    public String getRetrySubscriber() {
+        return retrySubscriber;
+    }
+
+    /**
+     * @param retrySubscriber the retrySubscriber to set
+     */
+    public void setRetrySubscriber(String retrySubscriber) {
+        this.retrySubscriber = retrySubscriber;
     }
 
     /**

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/AbstractPublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/AbstractPublisherJMS.java
@@ -94,17 +94,28 @@ public abstract class AbstractPublisherJMS<T> implements Publisher<T> {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List, long)
+    /**
+     * This method publishes the supplied items.
+     *
+     * @param tenantId The tenant id
+     * @param items The items
+     * @param subscriber The optional subscriber name
+     * @param retryCount The retry count
+     * @param delay The delay
+     * @throws Exception Failed to publish
      */
-    @Override
-    public void publish(String tenantId, List<T> items, int retryCount, long delay) throws Exception {
+    protected void doPublish(String tenantId, List<T> items, String subscriber,
+            int retryCount, long delay) throws Exception {
         String data = mapper.writeValueAsString(items);
 
         TextMessage tm = session.createTextMessage(data);
 
         if (tenantId != null) {
             tm.setStringProperty("tenant", tenantId);
+        }
+
+        if (subscriber != null) {
+            tm.setStringProperty("subscriber", subscriber);
         }
 
         tm.setIntProperty("retryCount", retryCount);
@@ -121,11 +132,27 @@ public abstract class AbstractPublisherJMS<T> implements Publisher<T> {
     }
 
     /* (non-Javadoc)
+     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List, long)
+     */
+    @Override
+    public void publish(String tenantId, List<T> items, int retryCount, long delay) throws Exception {
+        doPublish(tenantId, items, null, retryCount, delay);
+    }
+
+    /* (non-Javadoc)
      * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List)
      */
     @Override
     public void publish(String tenantId, List<T> items) throws Exception {
-        publish(tenantId, items, getInitialRetryCount(), 0);
+        doPublish(tenantId, items, null, getInitialRetryCount(), 0);
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
+     */
+    @Override
+    public void retry(String tenantId, List<T> items, String subscriber, int retryCount, long delay) throws Exception {
+        doPublish(tenantId, items, subscriber, retryCount, delay);
     }
 
     @PreDestroy

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsCacheMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsCacheMDB.java
@@ -41,16 +41,15 @@ import com.fasterxml.jackson.core.type.TypeReference;
  *
  * @author gbrown
  */
-@MessageDriven(name = "CommunicationDetails_CommunicationDetailsCache", messageListenerInterface = MessageListener.class,
-        activationConfig =
-        {
-                @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
-                @ActivationConfigProperty(propertyName = "destination", propertyValue = "CommunicationDetails"),
-                @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-                @ActivationConfigProperty(propertyName = "clientID", propertyValue = "apm-${jboss.node.name}"),
-                @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "CommunicationDetailsCache")
-        })
-public class CommunicationDetailsCacheMDB extends RetryCapableMDB<CommunicationDetails,Void> {
+@MessageDriven(name = "CommunicationDetails_CommunicationDetailsCache", messageListenerInterface = MessageListener.class, activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "CommunicationDetails"),
+        @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
+        @ActivationConfigProperty(propertyName = "clientID", propertyValue = "apm-${jboss.node.name}"),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = CommunicationDetailsCacheMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+CommunicationDetailsCacheMDB.SUBSCRIBER+"'")
+})
+public class CommunicationDetailsCacheMDB extends RetryCapableMDB<CommunicationDetails, Void> {
 
     @Inject
     private CommunicationDetailsPublisherJMS communicationDetailsPublisher;
@@ -58,13 +57,20 @@ public class CommunicationDetailsCacheMDB extends RetryCapableMDB<CommunicationD
     @Inject
     private CommunicationDetailsCache communicationDetailsCache;
 
+    /**  */
+    public static final String SUBSCRIBER = "CommunicationDetailsCache";
+
+    public CommunicationDetailsCacheMDB() {
+        super(SUBSCRIBER);
+    }
+
     @PostConstruct
     public void init() {
         setRetryPublisher(communicationDetailsPublisher);
         setTypeReference(new TypeReference<java.util.List<CommunicationDetails>>() {
         });
 
-        setProcessor(new AbstractProcessor<CommunicationDetails,Void>(ProcessorType.ManyToMany) {
+        setProcessor(new AbstractProcessor<CommunicationDetails, Void>(ProcessorType.ManyToMany) {
 
             @Override
             public List<Void> processManyToMany(String tenantId, List<CommunicationDetails> items) throws Exception {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsDeriverMDB.java
@@ -39,8 +39,9 @@ activationConfig =
     @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
     @ActivationConfigProperty(propertyName = "destination", propertyValue = "Traces"),
     @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-    @ActivationConfigProperty(propertyName = "clientID", propertyValue = "CommunicationDetailsDeriver"),
-    @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "CommunicationDetailsDeriver")
+    @ActivationConfigProperty(propertyName = "clientID", propertyValue = CommunicationDetailsDeriverMDB.SUBSCRIBER),
+    @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = CommunicationDetailsDeriverMDB.SUBSCRIBER),
+    @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+CommunicationDetailsDeriverMDB.SUBSCRIBER+"'")
 })
 public class CommunicationDetailsDeriverMDB extends RetryCapableMDB<Trace, CommunicationDetails> {
 
@@ -52,6 +53,13 @@ public class CommunicationDetailsDeriverMDB extends RetryCapableMDB<Trace, Commu
 
     @Inject
     private CommunicationDetailsDeriver communicationDetailsDeriver;
+
+    /**  */
+    public static final String SUBSCRIBER = "CommunicationDetailsDeriver";
+
+    public CommunicationDetailsDeriverMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsStoreMDB.java
@@ -38,8 +38,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "CommunicationDetails"),
         @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-        @ActivationConfigProperty(propertyName = "clientID", propertyValue = "CommunicationDetailsStore"),
-        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "CommunicationDetailsStore")
+        @ActivationConfigProperty(propertyName = "clientID", propertyValue = CommunicationDetailsStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = CommunicationDetailsStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+CommunicationDetailsStoreMDB.SUBSCRIBER+"'")
 })
 public class CommunicationDetailsStoreMDB extends RetryCapableMDB<CommunicationDetails, Void> {
 
@@ -48,6 +49,13 @@ public class CommunicationDetailsStoreMDB extends RetryCapableMDB<CommunicationD
 
     @Inject
     private AnalyticsService analyticsService;
+
+    /**  */
+    public static final String SUBSCRIBER = "CommunicationDetailsStore";
+
+    public CommunicationDetailsStoreMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeDeriverMDB.java
@@ -39,9 +39,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
                 @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
                 @ActivationConfigProperty(propertyName = "destination", propertyValue = "Traces"),
                 @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-                @ActivationConfigProperty(propertyName = "clientID", propertyValue = "FragmentCompletionTimeDeriver"),
+                @ActivationConfigProperty(propertyName = "clientID", propertyValue = FragmentCompletionTimeDeriverMDB.SUBSCRIBER),
                 @ActivationConfigProperty(propertyName = "subscriptionName",
-                            propertyValue = "FragmentCompletionTimeDeriver")
+                            propertyValue = FragmentCompletionTimeDeriverMDB.SUBSCRIBER),
+                @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+FragmentCompletionTimeDeriverMDB.SUBSCRIBER+"'")
         })
 public class FragmentCompletionTimeDeriverMDB extends RetryCapableMDB<Trace, CompletionTime> {
 
@@ -50,6 +51,13 @@ public class FragmentCompletionTimeDeriverMDB extends RetryCapableMDB<Trace, Com
 
     @Inject
     private FragmentCompletionTimePublisher fragmentCompletionTimePublisher;
+
+    /**  */
+    public static final String SUBSCRIBER = "FragmentCompletionTimeDeriver";
+
+    public FragmentCompletionTimeDeriverMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeStoreMDB.java
@@ -38,8 +38,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "FragmentCompletionTimes"),
         @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-        @ActivationConfigProperty(propertyName = "clientID", propertyValue = "FragmentCompletionTimeStore"),
-        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "FragmentCompletionTimeStore")
+        @ActivationConfigProperty(propertyName = "clientID", propertyValue = FragmentCompletionTimeStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = FragmentCompletionTimeStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+FragmentCompletionTimeStoreMDB.SUBSCRIBER+"'")
 })
 public class FragmentCompletionTimeStoreMDB extends RetryCapableMDB<CompletionTime, Void> {
 
@@ -48,6 +49,13 @@ public class FragmentCompletionTimeStoreMDB extends RetryCapableMDB<CompletionTi
 
     @Inject
     private AnalyticsService analyticsService;
+
+    /**  */
+    public static final String SUBSCRIBER = "FragmentCompletionTimeStore";
+
+    public FragmentCompletionTimeStoreMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsDeriverMDB.java
@@ -38,8 +38,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
                 @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
                 @ActivationConfigProperty(propertyName = "destination", propertyValue = "Traces"),
                 @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-                @ActivationConfigProperty(propertyName = "clientID", propertyValue = "NodeDetailsDeriver"),
-                @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "NodeDetailsDeriver")
+                @ActivationConfigProperty(propertyName = "clientID", propertyValue = NodeDetailsDeriverMDB.SUBSCRIBER),
+                @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = NodeDetailsDeriverMDB.SUBSCRIBER),
+                @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+NodeDetailsDeriverMDB.SUBSCRIBER+"'")
         })
 public class NodeDetailsDeriverMDB extends RetryCapableMDB<Trace, NodeDetails> {
 
@@ -48,6 +49,13 @@ public class NodeDetailsDeriverMDB extends RetryCapableMDB<Trace, NodeDetails> {
 
     @Inject
     private NodeDetailsPublisher nodeDetailsPublisher;
+
+    /**  */
+    public static final String SUBSCRIBER = "NodeDetailsDeriver";
+
+    public NodeDetailsDeriverMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsStoreMDB.java
@@ -38,8 +38,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "NodeDetails"),
         @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-        @ActivationConfigProperty(propertyName = "clientID", propertyValue = "NodeDetailsStore"),
-        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "NodeDetailsStore")
+        @ActivationConfigProperty(propertyName = "clientID", propertyValue = NodeDetailsStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = NodeDetailsStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+NodeDetailsStoreMDB.SUBSCRIBER+"'")
 })
 public class NodeDetailsStoreMDB extends RetryCapableMDB<NodeDetails, Void> {
 
@@ -48,6 +49,13 @@ public class NodeDetailsStoreMDB extends RetryCapableMDB<NodeDetails, Void> {
 
     @Inject
     private AnalyticsService analyticsService;
+
+    /**  */
+    public static final String SUBSCRIBER = "NodeDetailsStore";
+
+    public NodeDetailsStoreMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/NotificationDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/NotificationDeriverMDB.java
@@ -38,8 +38,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
                 @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
                 @ActivationConfigProperty(propertyName = "destination", propertyValue = "Traces"),
                 @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-                @ActivationConfigProperty(propertyName = "clientID", propertyValue = "NotificationDeriver"),
-                @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "NotificationDeriver")
+                @ActivationConfigProperty(propertyName = "clientID", propertyValue = NotificationDeriverMDB.SUBSCRIBER),
+                @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = NotificationDeriverMDB.SUBSCRIBER),
+                @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+NotificationDeriverMDB.SUBSCRIBER+"'")
         })
 public class NotificationDeriverMDB extends RetryCapableMDB<Trace, Notification> {
 
@@ -48,6 +49,13 @@ public class NotificationDeriverMDB extends RetryCapableMDB<Trace, Notification>
 
     @Inject
     private NotificationPublisher notificationPublisher;
+
+    /**  */
+    public static final String SUBSCRIBER = "NotificationDeriver";
+
+    public NotificationDeriverMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/RetryCapableMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/RetryCapableMDB.java
@@ -57,6 +57,17 @@ public abstract class RetryCapableMDB<S,T> implements MessageListener {
 
     private Publisher<T> publisher;
 
+    private String retrySubscriber;
+
+    /**
+     * This constructor initialises the retry capable MDB with the subscriber name.
+     *
+     * @param subscriberName The subscriber name
+     */
+    public RetryCapableMDB(String subscriberName) {
+        retrySubscriber = subscriberName;
+    }
+
     /**
      * @return the processor
      */
@@ -157,6 +168,7 @@ public abstract class RetryCapableMDB<S,T> implements MessageListener {
                 new ProcessingUnit<S, T>();
 
         pu.setProcessor(getProcessor());
+        pu.setRetrySubscriber(retrySubscriber);
         pu.setRetryCount(retryCount);
 
         pu.setResultHandler(
@@ -165,8 +177,8 @@ public abstract class RetryCapableMDB<S,T> implements MessageListener {
         );
 
         pu.setRetryHandler(
-                (tid, events) -> getRetryPublisher().publish(tid, events, pu.getRetryCount() - 1,
-                        getProcessor().getRetryDelay(events))
+                (tid, events) -> getRetryPublisher().retry(tid, events, pu.getRetrySubscriber(),
+                        pu.getRetryCount() - 1, getProcessor().getRetryDelay(events))
         );
 
         pu.handle(tenantId, items);

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionInformationInitiatorMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionInformationInitiatorMDB.java
@@ -40,9 +40,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
                 @ActivationConfigProperty(propertyName = "destination", propertyValue = "Traces"),
                 @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
                 @ActivationConfigProperty(propertyName = "clientID",
-                            propertyValue = "TraceCompletionInformationInitiator"),
+                            propertyValue = TraceCompletionInformationInitiatorMDB.SUBSCRIBER),
                 @ActivationConfigProperty(propertyName = "subscriptionName",
-                            propertyValue = "TraceCompletionInformationInitiator")
+                            propertyValue = TraceCompletionInformationInitiatorMDB.SUBSCRIBER),
+                @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+TraceCompletionInformationInitiatorMDB.SUBSCRIBER+"'")
         })
 public class TraceCompletionInformationInitiatorMDB
                 extends RetryCapableMDB<Trace, TraceCompletionInformation> {
@@ -52,6 +53,13 @@ public class TraceCompletionInformationInitiatorMDB
 
     @Inject
     private TraceCompletionInformationPublisher traceCompletionInformationPublisher;
+
+    /**  */
+    public static final String SUBSCRIBER = "TraceCompletionInformationInitiator";
+
+    public TraceCompletionInformationInitiatorMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionInformationProcessorMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionInformationProcessorMDB.java
@@ -38,9 +38,10 @@ activationConfig =
     @ActivationConfigProperty(propertyName = "destination", propertyValue = "TraceCompletionInformation"),
     @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
     @ActivationConfigProperty(propertyName = "clientID",
-                        propertyValue = "TraceCompletionInformationProcessor"),
+                        propertyValue = TraceCompletionInformationProcessorMDB.SUBSCRIBER),
     @ActivationConfigProperty(propertyName = "subscriptionName",
-                        propertyValue = "TraceCompletionInformationProcessor")
+                        propertyValue = TraceCompletionInformationProcessorMDB.SUBSCRIBER),
+    @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+TraceCompletionInformationProcessorMDB.SUBSCRIBER+"'")
 })
 public class TraceCompletionInformationProcessorMDB
         extends RetryCapableMDB<TraceCompletionInformation, TraceCompletionInformation> {
@@ -50,6 +51,13 @@ public class TraceCompletionInformationProcessorMDB
 
     @Inject
     private TraceCompletionInformationProcessor traceCompletionInformationProcessor;
+
+    /**  */
+    public static final String SUBSCRIBER = "TraceCompletionInformationProcessor";
+
+    public TraceCompletionInformationProcessorMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimeDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimeDeriverMDB.java
@@ -39,9 +39,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
                 @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
                 @ActivationConfigProperty(propertyName = "destination", propertyValue = "TraceCompletionInformation"),
                 @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-                @ActivationConfigProperty(propertyName = "clientID", propertyValue = "TraceCompletionTimeDeriver"),
+                @ActivationConfigProperty(propertyName = "clientID", propertyValue = TraceCompletionTimeDeriverMDB.SUBSCRIBER),
                 @ActivationConfigProperty(propertyName = "subscriptionName",
-                            propertyValue = "TraceCompletionTimeDeriver")
+                            propertyValue = TraceCompletionTimeDeriverMDB.SUBSCRIBER),
+                @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+TraceCompletionTimeDeriverMDB.SUBSCRIBER+"'")
         })
 public class TraceCompletionTimeDeriverMDB extends RetryCapableMDB<TraceCompletionInformation, CompletionTime> {
 
@@ -50,6 +51,13 @@ public class TraceCompletionTimeDeriverMDB extends RetryCapableMDB<TraceCompleti
 
     @Inject
     private TraceCompletionTimePublisher traceCompletionTimePublisher;
+
+    /**  */
+    public static final String SUBSCRIBER = "TraceCompletionTimeDeriver";
+
+    public TraceCompletionTimeDeriverMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimeStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimeStoreMDB.java
@@ -38,8 +38,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "TraceCompletionTimes"),
         @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-        @ActivationConfigProperty(propertyName = "clientID", propertyValue = "TraceCompletionTimeStore"),
-        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "TraceCompletionTimeStore")
+        @ActivationConfigProperty(propertyName = "clientID", propertyValue = TraceCompletionTimeStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = TraceCompletionTimeStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+TraceCompletionTimeStoreMDB.SUBSCRIBER+"'")
 })
 public class TraceCompletionTimeStoreMDB extends RetryCapableMDB<CompletionTime, Void> {
 
@@ -48,6 +49,13 @@ public class TraceCompletionTimeStoreMDB extends RetryCapableMDB<CompletionTime,
 
     @Inject
     private AnalyticsService analyticsService;
+
+    /**  */
+    public static final String SUBSCRIBER = "TraceCompletionTimeStore";
+
+    public TraceCompletionTimeStoreMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceStoreMDB.java
@@ -38,8 +38,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "Traces"),
         @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
-        @ActivationConfigProperty(propertyName = "clientID", propertyValue = "TraceStore"),
-        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "TraceStore")
+        @ActivationConfigProperty(propertyName = "clientID", propertyValue = TraceStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = TraceStoreMDB.SUBSCRIBER),
+        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "subscriber IS NULL OR subscriber = '"+TraceStoreMDB.SUBSCRIBER+"'")
 })
 public class TraceStoreMDB extends RetryCapableMDB<Trace, Void> {
 
@@ -48,6 +49,13 @@ public class TraceStoreMDB extends RetryCapableMDB<Trace, Void> {
 
     @Inject
     private TraceService traceService;
+
+    /**  */
+    public static final String SUBSCRIBER = "TraceStore";
+
+    public TraceStoreMDB() {
+        super(SUBSCRIBER);
+    }
 
     @PostConstruct
     public void init() {


### PR DESCRIPTION
… to all subscribers of a topic. This fix uses message selectors that initially will process messages not associated with a specific subscriber, but if a retry is triggered then the message will be published to the same topic, but with a 'subscriber' name to ensure only the appropriate subscriber processes the retried message