### PR TITLE
HWKAPM-508 Check that service implementations are available before us…

### DIFF
--- a/performance/server/src/main/java/org/hawkular/apm/performance/server/ClientSimulator.java
+++ b/performance/server/src/main/java/org/hawkular/apm/performance/server/ClientSimulator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.PublisherMetricHandler;
@@ -34,6 +35,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author gbrown
  */
 public class ClientSimulator {
+
+    private static final Logger log = Logger.getLogger(ClientSimulator.class.getName());
 
     private SystemConfiguration systemConfig;
 
@@ -88,6 +91,11 @@ public class ClientSimulator {
 
         // Initialise publisher metrics handler
         TracePublisher publisher = ServiceResolver.getSingletonService(TracePublisher.class);
+        if (publisher == null) {
+            log.severe("Trace publisher has not been configured correctly");
+            return;
+        }
+
         publisher.setMetricHandler(new PublisherMetricHandler<Trace>() {
             @Override
             public void published(String tenantId, List<Trace> items, long metric) {

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/AbstractConsumerKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/AbstractConsumerKafka.java
@@ -170,6 +170,11 @@ public class AbstractConsumerKafka<S, T> implements KafkaProcessor {
 
     @Override
     public void run() {
+        // If no processor, then don't start comsuming records
+        if (getProcessor() == null) {
+            return;
+        }
+
         while (true) {
             ConsumerRecords<String, String> records = consumer.poll(getPollingInterval());
 
@@ -185,7 +190,7 @@ public class AbstractConsumerKafka<S, T> implements KafkaProcessor {
 
                 try {
                     if (log.isLoggable(Level.FINEST)) {
-                        log.finest(getClass().getSimpleName()+": received " + items.size() +
+                        log.finest(getClass().getSimpleName() + ": received " + items.size() +
                                 " records after polling " + getPollingInterval() + "ms");
                     }
                     process(null, items, 1);

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeDeriverKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeDeriverKafka.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.apm.server.kafka;
 
+import java.util.logging.Logger;
+
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.ServiceResolver;
@@ -29,6 +31,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
  */
 public class FragmentCompletionTimeDeriverKafka extends AbstractConsumerKafka<Trace, CompletionTime> {
 
+    private static final Logger log = Logger.getLogger(FragmentCompletionTimeDeriverKafka.class.getName());
+
     /**  */
     private static final String GROUP_ID = "FragmentCompletionTimeDeriver";
 
@@ -40,9 +44,14 @@ public class FragmentCompletionTimeDeriverKafka extends AbstractConsumerKafka<Tr
 
         setPublisher(ServiceResolver.getSingletonService(FragmentCompletionTimePublisher.class));
 
-        setTypeReference(new TypeReference<Trace>() {
-        });
+        if (getPublisher() == null) {
+            log.severe("Fragment Completion Time Publisher not found - possibly not configured correctly");
+        } else {
 
-        setProcessor(new FragmentCompletionTimeDeriver());
+            setTypeReference(new TypeReference<Trace>() {
+            });
+
+            setProcessor(new FragmentCompletionTimeDeriver());
+        }
     }
 }

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeStoreKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeStoreKafka.java
@@ -17,6 +17,7 @@
 package org.hawkular.apm.server.kafka;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.api.services.AnalyticsService;
@@ -33,6 +34,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
  */
 public class FragmentCompletionTimeStoreKafka extends AbstractConsumerKafka<CompletionTime, Void> {
 
+    private static final Logger log = Logger.getLogger(FragmentCompletionTimeStoreKafka.class.getName());
+
     /**  */
     private static final String GROUP_ID = "FragmentCompletionTimeStore";
 
@@ -46,21 +49,26 @@ public class FragmentCompletionTimeStoreKafka extends AbstractConsumerKafka<Comp
 
         analyticsService = ServiceResolver.getSingletonService(AnalyticsService.class);
 
-        setTypeReference(new TypeReference<CompletionTime>() {
-        });
+        if (analyticsService == null) {
+            log.severe("Analytics Service not found - possibly not configured correctly");
+        } else {
 
-        setProcessor(new AbstractProcessor<CompletionTime, Void>(ProcessorType.ManyToMany) {
+            setTypeReference(new TypeReference<CompletionTime>() {
+            });
 
-            @Override
-            public List<Void> processManyToMany(String tenantId, List<CompletionTime> items)
-                    throws RetryAttemptException {
-                try {
-                    analyticsService.storeFragmentCompletionTimes(tenantId, items);
-                } catch (StoreException se) {
-                    throw new RetryAttemptException(se);
+            setProcessor(new AbstractProcessor<CompletionTime, Void>(ProcessorType.ManyToMany) {
+
+                @Override
+                public List<Void> processManyToMany(String tenantId, List<CompletionTime> items)
+                        throws RetryAttemptException {
+                    try {
+                        analyticsService.storeFragmentCompletionTimes(tenantId, items);
+                    } catch (StoreException se) {
+                        throw new RetryAttemptException(se);
+                    }
+                    return null;
                 }
-                return null;
-            }
-        });
+            });
+        }
     }
 }

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsDeriverKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsDeriverKafka.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.apm.server.kafka;
 
+import java.util.logging.Logger;
+
 import org.hawkular.apm.api.model.events.NodeDetails;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.ServiceResolver;
@@ -29,6 +31,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
  */
 public class NodeDetailsDeriverKafka extends AbstractConsumerKafka<Trace, NodeDetails> {
 
+    private static final Logger log = Logger.getLogger(NodeDetailsDeriverKafka.class.getName());
+
     /**  */
     private static final String GROUP_ID = "NodeDetailsDeriver";
 
@@ -40,9 +44,14 @@ public class NodeDetailsDeriverKafka extends AbstractConsumerKafka<Trace, NodeDe
 
         setPublisher(ServiceResolver.getSingletonService(NodeDetailsPublisher.class));
 
-        setTypeReference(new TypeReference<Trace>() {
-        });
+        if (getPublisher() == null) {
+            log.severe("Node Details Publisher not found - possibly not configured correctly");
+        } else {
 
-        setProcessor(new NodeDetailsDeriver());
+            setTypeReference(new TypeReference<Trace>() {
+            });
+
+            setProcessor(new NodeDetailsDeriver());
+        }
     }
 }

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationInitiatorKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationInitiatorKafka.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.apm.server.kafka;
 
+import java.util.logging.Logger;
+
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.ServiceResolver;
 import org.hawkular.apm.processor.tracecompletiontime.TraceCompletionInformation;
@@ -30,6 +32,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 public class TraceCompletionInformationInitiatorKafka
         extends AbstractConsumerKafka<Trace, TraceCompletionInformation> {
 
+    private static final Logger log = Logger.getLogger(TraceCompletionInformationInitiatorKafka.class.getName());
+
     /**  */
     private static final String GROUP_ID = "TraceCompletionInformationInitiator";
 
@@ -41,9 +45,14 @@ public class TraceCompletionInformationInitiatorKafka
 
         setPublisher(ServiceResolver.getSingletonService(TraceCompletionInformationPublisher.class));
 
-        setTypeReference(new TypeReference<Trace>() {
-        });
+        if (getPublisher() == null) {
+            log.severe("Trace Completion Information Publisher not found - possibly not configured correctly");
+        } else {
 
-        setProcessor(new TraceCompletionInformationInitiator());
+            setTypeReference(new TypeReference<Trace>() {
+            });
+
+            setProcessor(new TraceCompletionInformationInitiator());
+        }
     }
 }

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimeDeriverKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimeDeriverKafka.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.apm.server.kafka;
 
+import java.util.logging.Logger;
+
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.api.services.ServiceResolver;
 import org.hawkular.apm.processor.tracecompletiontime.TraceCompletionInformation;
@@ -30,6 +32,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 public class TraceCompletionTimeDeriverKafka
         extends AbstractConsumerKafka<TraceCompletionInformation, CompletionTime> {
 
+    private static final Logger log = Logger.getLogger(TraceCompletionTimeDeriverKafka.class.getName());
+
     private static final String GROUP_ID = "TraceCompletionTimeDeriver";
 
     /**  */
@@ -38,12 +42,17 @@ public class TraceCompletionTimeDeriverKafka
     public TraceCompletionTimeDeriverKafka() {
         super(TOPIC, GROUP_ID);
 
-        setProcessor(new TraceCompletionTimeDeriver());
-
         setPublisher(ServiceResolver.getSingletonService(TraceCompletionTimePublisher.class));
 
-        setTypeReference(new TypeReference<TraceCompletionInformation>() {
-        });
+        if (getPublisher() == null) {
+            log.severe("Trace Completion Time Publisher not found - possibly not configured correctly");
+        } else {
+
+            setProcessor(new TraceCompletionTimeDeriver());
+
+            setTypeReference(new TypeReference<TraceCompletionInformation>() {
+            });
+        }
     }
 
 }


### PR DESCRIPTION
…e. Previously this could be guaranteed if the impls were packaged correctly, but since the introduction of a runtime check (HWKAPM-492) to determine if the service impl has the appropriate config to be used, it is possible that no impl will be returned - so needs to be handled in client code