### PR TITLE
HWKAPM-519 Fix npe and producer info not found issues when instrument…

### DIFF
--- a/processors/zipkin/src/main/java/org/hawkular/apm/processor/zipkin/CommunicationDetailsDeriver.java
+++ b/processors/zipkin/src/main/java/org/hawkular/apm/processor/zipkin/CommunicationDetailsDeriver.java
@@ -84,6 +84,16 @@ public class CommunicationDetailsDeriver extends AbstractProcessor<Span, Communi
     }
 
     /* (non-Javadoc)
+     * @see org.hawkular.apm.server.api.task.Processor#isReportRetryExpirationAsWarning()
+     */
+    @Override
+    public boolean isReportRetryExpirationAsWarning() {
+        // We don't want to report a warning, as server spans with no matching client span
+        // will result in the retry expiration
+        return false;
+    }
+
+    /* (non-Javadoc)
      * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
      */
     @Override

--- a/server/api/src/main/java/org/hawkular/apm/server/api/model/zipkin/Span.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/model/zipkin/Span.java
@@ -48,9 +48,9 @@ public class Span {
 
     private Boolean debug;
 
-    private Long timestamp;
+    private long timestamp;
 
-    private Long duration;
+    private long duration;
 
     /**
      * @return the traceId
@@ -153,28 +153,28 @@ public class Span {
     /**
      * @return the timestamp
      */
-    public Long getTimestamp() {
+    public long getTimestamp() {
         return timestamp;
     }
 
     /**
      * @param timestamp the timestamp to set
      */
-    public void setTimestamp(Long timestamp) {
+    public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
     }
 
     /**
      * @return the duration
      */
-    public Long getDuration() {
+    public long getDuration() {
         return duration;
     }
 
     /**
      * @param duration the duration to set
      */
-    public void setDuration(Long duration) {
+    public void setDuration(long duration) {
         this.duration = duration;
     }
 

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/AbstractProcessor.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/AbstractProcessor.java
@@ -85,6 +85,14 @@ public abstract class AbstractProcessor<T, R> implements Processor<T,R> {
     }
 
     /* (non-Javadoc)
+     * @see org.hawkular.apm.server.api.task.Processor#isReportRetryExpirationAsWarning()
+     */
+    @Override
+    public boolean isReportRetryExpirationAsWarning() {
+        return true;
+    }
+
+    /* (non-Javadoc)
      * @see org.hawkular.apm.server.api.task.Processor#processOneToOne(java.lang.String, java.lang.Object)
      */
     @Override

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/Processor.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/Processor.java
@@ -96,6 +96,14 @@ public interface Processor<T, R> {
     long getRetryDelay(List<T> items, int retryCount);
 
     /**
+     * This method determines whether a retry expiration should be reported as
+     * a warning. If not, then it will just be logged as detailed logging.
+     *
+     * @return Whether to report retry expiration as a warning message
+     */
+    boolean isReportRetryExpirationAsWarning();
+
+    /**
      * This method is called once all of the items in the list of been
      * processed to generate new information. It can be used to
      * clean up any information managed by the processor related to

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/RetryCapableMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/RetryCapableMDB.java
@@ -158,7 +158,11 @@ public abstract class RetryCapableMDB<S,T> implements MessageListener {
             process(tenantId, items, retryCount);
 
         } catch (Exception e) {
-            serverMsgLogger.warnMaxRetryReached(e);
+            if (processor.isReportRetryExpirationAsWarning()) {
+                serverMsgLogger.warnMaxRetryReached(e);
+            } else if (log.isLoggable(Level.FINEST)) {
+                log.log(Level.FINEST, "Maximum retry reached. Last exception to occur ....", e);
+            }
         }
     }
 


### PR DESCRIPTION
…ing node.js via zipkin. NPE was related to client not providing a duration Long, and produce info not found is expected in this case, but should not be reported as a warning