### PR TITLE
HWKAPM-525 | Span Service and Elasticsearch Impl

### DIFF
--- a/server/api/src/main/java/org/hawkular/apm/server/api/services/SpanService.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/services/SpanService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.apm.server.api.services;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.hawkular.apm.api.services.StoreException;
+import org.hawkular.apm.server.api.model.zipkin.Span;
+
+/**
+ * This interface represents the service used to store and retrieve spans.
+ *
+ * @author Pavol Loffay
+ */
+public interface SpanService {
+
+    /**
+     * This method returns a span of a given id.
+     *
+     * @param tenantId The tenant
+     * @param id The span id
+     * @return Span or null when there is no such span.
+     * @throws IllegalStateException when failed to deserialize json from a database.
+     */
+    Span getSpan(String tenantId, String id);
+
+    /**
+     * This method returns all children of a given span.
+     *
+     * @param tenantId The Tenant
+     * @param id The span id
+     * @return List of spans with parent id equals to given id or an empty list.
+     * @throws IllegalStateException when failed to deserialize json from a database.
+     */
+    List<Span> getChildren(String tenantId, String id);
+
+    /**
+     * This method stores the supplied list of spans.
+     *
+     * @param tenantId The tenant id
+     * @param spans The spans
+     * @throws StoreException Is thrown when spans could not be serialized to json or stored into database.
+     */
+    void storeSpan(String tenantId, List<Span> spans) throws StoreException;
+
+    /**
+     * This method stores the supplied list of spans.
+     *
+     * @param tenantId The tenant id
+     * @param spans The spans
+     * @param spanIdSupplier Function which is used to generate span id for indexing. Therefore this new id should
+     *                       be used for following spans querying.
+     * @throws StoreException Is thrown when spans could not be serialized to json or stored into database.
+     */
+    void storeSpan(String tenantId, List<Span> spans, Function<Span, String> spanIdSupplier) throws StoreException;
+
+    /**
+     * This method clears the span data for the supplied tenant.
+     *
+     * @param tenantId The tenant id
+     */
+    void clear(String tenantId);
+}

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchClient.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchClient.java
@@ -18,9 +18,9 @@ package org.hawkular.apm.server.elasticsearch;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -91,7 +91,7 @@ public class ElasticsearchClient {
 
     private static ElasticsearchEmbeddedNode node = null;
 
-    private static List<String> knownTenants = new ArrayList<String>();
+    private static Set<String> knownTenants = new HashSet<>();
 
     private static ElasticsearchClient singleton;
 

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/SpanServiceElasticsearch.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/SpanServiceElasticsearch.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.apm.server.elasticsearch;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequestBuilder;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.search.SearchHit;
+import org.hawkular.apm.api.services.StoreException;
+import org.hawkular.apm.server.api.model.zipkin.Span;
+import org.hawkular.apm.server.api.services.SpanService;
+import org.hawkular.apm.server.elasticsearch.log.MsgLogger;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Pavol Loffay
+ */
+public class SpanServiceElasticsearch implements SpanService {
+
+    private static final MsgLogger log = MsgLogger.LOGGER;
+
+    public static final String SPAN_TYPE = "span";
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private ElasticsearchClient client = ElasticsearchClient.getSingleton();
+
+
+    @Override
+    public Span getSpan(String tenantId, String id) {
+
+        GetResponse response = null;
+        try {
+            response = client.getClient()
+                    .prepareGet(client.getIndex(tenantId), SPAN_TYPE, id)
+                    .setRouting(id)
+                    .execute()
+                    .actionGet();
+        } catch (IndexMissingException ex) {
+            log.errorf("Missing span index %s", tenantId);
+            return null;
+        }
+
+        Span span = null;
+        if (!response.isSourceEmpty()) {
+            try {
+                span = deserialize(response.getSourceAsString(), Span.class);
+            } catch (IOException ex) {
+                log.errorFailedToParse(ex);
+                throw new IllegalStateException("Failed to deserialize span", ex);
+            }
+        }
+
+        log.tracef("Get span with id[%s] is: %s", id, span);
+
+        return span;
+    }
+
+    @Override
+    public List<Span> getChildren(String tenantId, String id) {
+
+        List<Span> spans = new ArrayList<>();
+        final String index = client.getIndex(tenantId);
+        try {
+
+            RefreshRequestBuilder refreshRequestBuilder = client.getClient()
+                    .admin()
+                    .indices()
+                    .prepareRefresh(index);
+
+            client.getClient()
+                    .admin()
+                    .indices()
+                    .refresh(refreshRequestBuilder.request())
+                    .actionGet();
+
+            QueryBuilder query = QueryBuilders.termQuery("parentId", id);
+
+            SearchRequestBuilder request = client.getClient()
+                    .prepareSearch(index)
+                    .setTypes(SPAN_TYPE)
+                    .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                    .setQuery(query);
+
+            SearchResponse response = request.execute()
+                    .actionGet();
+
+            for (SearchHit searchHitFields : response.getHits()) {
+                try {
+                    spans.add(deserialize(searchHitFields.getSourceAsString(), Span.class));
+                } catch (IOException ex) {
+                    log.errorFailedToParse(ex);
+                    throw new IllegalStateException("Failed to deserialize span", ex);
+                }
+            }
+        } catch (IndexMissingException ex) {
+            log.errorf("No index[%s] found, so unable to retrieve spans", index);
+        }
+
+        log.tracef("Get children with parentId[%s] is: %s", id, spans);
+        return spans;
+    }
+
+    @Override
+    public void storeSpan(String tenantId, List<Span> spans) throws StoreException {
+        storeSpan(tenantId, spans, span -> span.getId());
+    }
+
+    @Override
+    public void storeSpan(String tenantId, List<Span> spans, Function<Span, String> spanIdSupplier)
+            throws StoreException {
+
+        client.initTenant(tenantId);
+
+        BulkRequestBuilder bulkRequestBuilder = client.getClient().prepareBulk();
+
+        for (Span span : spans) {
+            String json;
+            try {
+                json = serialize(span);
+            } catch(IOException ex){
+                log.errorf("Failed to serialize span %s", span);
+                throw new StoreException(ex);
+            }
+
+            log.tracef("Storing span: %s", json);
+            // modified id is used in index
+            final String modifiedId = spanIdSupplier.apply(span);
+
+            bulkRequestBuilder.add(client.getClient()
+                    .prepareIndex(client.getIndex(tenantId), SPAN_TYPE, modifiedId)
+                    .setSource(json));
+        }
+
+        BulkResponse bulkItemResponses = bulkRequestBuilder.execute().actionGet();
+
+        if (bulkItemResponses.hasFailures()) {
+            log.tracef("Failed to store traces to elasticsearch: %s", bulkItemResponses.buildFailureMessage());
+            throw new StoreException(bulkItemResponses.buildFailureMessage());
+        }
+
+        log.trace("Success storing traces to elasticsearch");
+    }
+
+    @Override
+    public void clear(String tenantId) {
+        String index = client.getIndex(tenantId);
+
+        IndicesAdminClient indices = client.getClient().admin().indices();
+
+        boolean indexExists = indices.prepareExists(index)
+                .execute()
+                .actionGet()
+                .isExists();
+
+        if (indexExists) {
+            indices.prepareDelete(index)
+                    .execute()
+                    .actionGet();
+
+            client.clear(tenantId);
+        }
+    }
+
+    private <T> T deserialize(String json, Class<T> type) throws IOException {
+        JsonParser parser = mapper.getFactory().createParser(json);
+
+        return parser.readValueAs(type);
+    }
+
+    private String serialize(Object object) throws IOException {
+        StringWriter out = new StringWriter();
+
+        JsonGenerator gen = mapper.getFactory().createGenerator(out);
+        gen.writeObject(object);
+
+        gen.close();
+        out.close();
+
+        return out.toString();
+    }
+}

--- a/server/elasticsearch/src/main/resources/hawkular-apm-mapping.json
+++ b/server/elasticsearch/src/main/resources/hawkular-apm-mapping.json
@@ -180,7 +180,8 @@
                     "index": "not_analyzed"
                 },
                 "duration": {
-                    "type": "long"
+                    "type": "long",
+                    "index": "not_analyzed"
                 },
                 "correlationIds": {
                     "type": "nested",
@@ -331,6 +332,123 @@
                         },
                         "number": {
                             "type": "double"
+                        }
+                    }
+                }
+            }
+        },
+        "span": {
+            "dynamic_templates": [{
+                "notanalyzed": {
+                    "match": "*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "type": "string",
+                        "index": "not_analyzed"
+                    }
+                }
+            }],
+            "date_detection": false,
+            "numeric_detection": false,
+            "_timestamp": {
+                "enabled": true,
+                "path": "timestamp",
+                "format": "yyyy/MM/dd HH:mm:ss"
+            },
+            "properties": {
+                "traceId": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "name": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "id": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "parentId": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "timestamp": {
+                    "type": "date",
+                    "format": "yyyy/MM/dd HH:mm:ss"
+                },
+                "duration": {
+                    "type": "long"
+                },
+                "debug": {
+                    "type": "boolean"
+                },
+                "annotations" : {
+                    "type": "nested",
+                    "include_in_parent": true,
+                    "include_in_root": true,
+                    "properties": {
+                        "timestamp": {
+                            "type": "date",
+                            "format": "yyyy/MM/dd HH:mm:ss"
+                        },
+                        "value": {
+                            "type": "string",
+                            "index": "not_analyzed"
+                        },
+                        "endpoint": {
+                            "type": "nested",
+                            "include_in_parent": true,
+                            "include_in_root": true,
+                            "properties": {
+                                "ipv4": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "serviceName": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        }
+                    }
+                },
+                "binaryAnnotations": {
+                    "type": "nested",
+                    "include_in_parent": true,
+                    "include_in_root": true,
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "index": "not_analyzed"
+                        },
+                        "value": {
+                            "type": "string",
+                            "index": "not_analyzed"
+                        },
+                        "endpoint": {
+                            "type": "nested",
+                            "include_in_parent": true,
+                            "include_in_root": true,
+                            "properties": {
+                                "ipv4": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "serviceName": {
+                                    "type": "string",
+                                    "index": "not_analyzed"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "index": "not_analyzed"
                         }
                     }
                 }

--- a/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/SpanServiceElasticsearchTest.java
+++ b/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/SpanServiceElasticsearchTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.apm.server.elasticsearch;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import org.hawkular.apm.api.services.StoreException;
+import org.hawkular.apm.server.api.model.zipkin.Annotation;
+import org.hawkular.apm.server.api.model.zipkin.AnnotationType;
+import org.hawkular.apm.server.api.model.zipkin.BinaryAnnotation;
+import org.hawkular.apm.server.api.model.zipkin.Endpoint;
+import org.hawkular.apm.server.api.model.zipkin.Span;
+import org.hawkular.apm.server.api.services.SpanService;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Pavol Loffay
+ */
+public class SpanServiceElasticsearchTest {
+
+    private SpanService spanService;
+
+    @BeforeClass
+    public static void initClass() {
+        System.setProperty("HAWKULAR_APM_CONFIG_DIR", "target");
+    }
+
+    @Before
+    public void beforeTest() {
+        spanService = new SpanServiceElasticsearch();
+    }
+
+    @After
+    public void afterTest() {
+        spanService.clear(null);
+    }
+
+    @Test
+    public void testStoreOneAndGetOne() throws StoreException, InterruptedException {
+        Annotation annotation = new Annotation();
+        annotation.setValue("foo bar");
+        annotation.setTimestamp(123456789L);
+        annotation.setEndpoint(createEndpoint("123.123.123.1233", 123, "foo service"));
+
+        BinaryAnnotation binaryAnnotation = new BinaryAnnotation();
+        binaryAnnotation.setEndpoint(createEndpoint("123.123.123.1233", 123, "foo service"));
+        binaryAnnotation.setValue("foo");
+        binaryAnnotation.setKey("foo key");
+        binaryAnnotation.setType(AnnotationType.I64);
+
+        Span span = new Span();
+        span.setId("id");
+        span.setTraceId("traceId");
+        span.setParentId("parentId");
+        span.setName("foo");
+        span.setDebug(true);
+        span.setTimestamp(1234456L);
+        span.setDuration(55468L);
+        span.setAnnotations(Arrays.asList(annotation));
+        span.setBinaryAnnotations(Arrays.asList(binaryAnnotation));
+
+        storeAndWait(null, span);
+        Span spanFromDb = spanService.getSpan(null, span.getId());
+
+        assertSpansEquals(span, spanFromDb);
+    }
+
+    @Test
+    public void testGetChildren() throws StoreException, InterruptedException {
+        Span parentSpan = new Span();
+        parentSpan.setId("parent");
+        parentSpan.setName("foo parent");
+
+        storeAndWait(null, parentSpan);
+
+        Annotation annotation = new Annotation();
+        annotation.setValue("foo bar");
+        annotation.setTimestamp(123456789);
+        annotation.setEndpoint(createEndpoint("123.123.123.1233", 123, "foo service"));
+
+        BinaryAnnotation binaryAnnotation = new BinaryAnnotation();
+        binaryAnnotation.setEndpoint(createEndpoint("123.123.123.1233", 123, "foo service"));
+        binaryAnnotation.setValue("foo");
+        binaryAnnotation.setKey("foo key");
+        binaryAnnotation.setType(AnnotationType.I64);
+
+        Span span = new Span();
+        span.setId("id1");
+        span.setTraceId("traceId");
+        span.setParentId("parent");
+        span.setName("foo");
+        span.setDebug(true);
+        span.setTimestamp(1234456L);
+        span.setDuration(55468L);
+        span.setAnnotations(Arrays.asList(annotation));
+        span.setBinaryAnnotations(Arrays.asList(binaryAnnotation));
+
+        storeAndWait(null, span);
+
+        span = new Span();
+        span.setId("id2");
+        span.setParentId("parent");
+
+        storeAndWait(null, span);
+
+        List<Span> children = spanService.getChildren(null, "parent");
+
+        Assert.assertEquals(2, children.size());
+    }
+
+    @Test
+    public void testStoreWithIdSupplier() throws StoreException, InterruptedException {
+        final String clientIdsuffix = "-client";
+
+        Span clientSpan = new Span();
+        clientSpan.setId("foo");
+        clientSpan.setDuration(111);
+        clientSpan.setAnnotations(annotations());
+
+        storeAndWait(null, clientSpan, x -> x.getId() + clientIdsuffix);
+
+        Span span = new Span();
+        span.setId("foo");
+        span.setDuration(444);
+
+        storeAndWait(null, span, x -> x.getId());
+
+        Span spanFromDb = spanService.getSpan(null, "foo");
+        assertSpansEquals(span, spanFromDb);
+
+        spanFromDb = spanService.getSpan(null, "foo" + clientIdsuffix);
+        assertSpansEquals(clientSpan, spanFromDb);
+    }
+
+    @Test
+    public void testGetChildrenFromEmptyDB() throws StoreException, InterruptedException {
+        List<Span> spans = spanService.getChildren(null, "id");
+        Assert.assertTrue(spans.isEmpty());
+    }
+
+    @Test
+    public void testGetChildrenTenantIndexExists() throws StoreException, InterruptedException {
+        storeAndWait(null, new Span());
+        List<Span> spans = spanService.getChildren(null, "id");
+        Assert.assertTrue(spans.isEmpty());
+    }
+
+    @Test
+    public void testGetSpanFromEmptyDB() throws StoreException, InterruptedException {
+        Span spanFromDB = spanService.getSpan(null, "id");
+        Assert.assertNull(spanFromDB);
+    }
+
+    private void storeAndWait(String tenant, Span span) throws StoreException, InterruptedException {
+        spanService.storeSpan(tenant, Arrays.asList(span));
+        synchronized (this) {
+            wait(1000);
+        }
+    }
+
+    private void storeAndWait(String tenant, Span span, Function<Span, String> idSupplier) throws StoreException,
+            InterruptedException {
+        spanService.storeSpan(tenant, Arrays.asList(span), idSupplier);
+        synchronized (this) {
+            wait(1000);
+        }
+    }
+
+    private Endpoint createEndpoint(String ipv4, int port, String serviceName) {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setIpv4(ipv4);
+        endpoint.setPort(port);
+        endpoint.setServiceName(serviceName);
+
+        return endpoint;
+    }
+
+    private void assertSpansEquals(Span expected, Span actual) {
+        Assert.assertEquals(expected.getId(), actual.getId());
+        Assert.assertEquals(expected.getTraceId(), actual.getTraceId());
+        Assert.assertEquals(expected.getParentId(), actual.getParentId());
+        Assert.assertEquals(expected.getName(), actual.getName());
+        Assert.assertEquals(expected.getDuration(), actual.getDuration());
+        Assert.assertEquals(expected.getTimestamp(), actual.getTimestamp());
+        Assert.assertEquals(expected.getDebug(), actual.getDebug());
+
+        Assert.assertEquals(expected.getAnnotations().size(), actual.getAnnotations().size());
+        Assert.assertEquals(expected.getBinaryAnnotations().size(), actual.getBinaryAnnotations().size());
+
+        for (int i = 0; i < expected.getAnnotations().size(); i++) {
+            assertAnnotationsEquals(expected.getAnnotations().get(i), actual.getAnnotations().get(i));
+        }
+        for (int i = 0; i < expected.getBinaryAnnotations().size(); i++) {
+            assertBinaryAnnotationsEquals(expected.getBinaryAnnotations().get(i), actual.getBinaryAnnotations().get(i));
+        }
+    }
+
+    private void assertAnnotationsEquals(Annotation expected, Annotation actual) {
+        Assert.assertEquals(expected.getTimestamp(), actual.getTimestamp());
+        Assert.assertEquals(expected.getValue(), actual.getValue());
+
+        assertEndpointsEquals(expected.getEndpoint(), actual.getEndpoint());
+    }
+
+    private void assertBinaryAnnotationsEquals(BinaryAnnotation expected, BinaryAnnotation actual) {
+        Assert.assertEquals(expected.getValue(), actual.getValue());
+        Assert.assertEquals(expected.getKey(), actual.getKey());
+        Assert.assertEquals(expected.getType(), actual.getType());
+
+        assertEndpointsEquals(expected.getEndpoint(), actual.getEndpoint());
+    }
+
+    private void assertEndpointsEquals(Endpoint expected, Endpoint actual) {
+        if (expected == null && actual == null) {
+            return;
+        } else if (expected == null && actual != null || expected != null && actual == null) {
+            Assert.fail();
+        }
+
+        Assert.assertEquals(expected.getServiceName(), actual.getServiceName());
+        Assert.assertEquals(expected.getPort(), actual.getPort());
+        Assert.assertEquals(expected.getIpv4(), actual.getIpv4());
+    }
+
+    private List<Annotation> annotations() {
+        Annotation csAnnotation = new Annotation();
+        csAnnotation.setValue("cs");
+        Annotation crAnnotation = new Annotation();
+        crAnnotation.setValue("cr");
+
+        return Collections.unmodifiableList(Arrays.asList(csAnnotation, crAnnotation));
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-525


Review notes:
* `SpanService.store()` takes the same function as `SpanCache` to modify ids of given spans. However, modified ids are not stored in span entity but only as an index.