### PR TITLE
HWKAPM-561 Updated vertx HTTP rules to use uri() method instead of in…

### DIFF
--- a/client/instrumentation-jvm/src/main/resources/apmconfig/jvm/io/vertx/apm-vertx-http.json
+++ b/client/instrumentation-jvm/src/main/resources/apmconfig/jvm/io/vertx/apm-vertx-http.json
@@ -103,7 +103,7 @@
         },{
           "name": "uri",
           "type": "java.net.URI",
-          "expression": "new java.net.URI(\"http://\"+$0.host+\":\"+$0.port+$0.request.getUri())"
+          "expression": "new java.net.URI(\"http://\"+$0.host+\":\"+$0.port+$0.uri())"
         }],
         "condition": "activate(uri.getPath(),$0.method())",
         "actions": [{
@@ -172,7 +172,7 @@
         },{
           "name": "uri",
           "type": "java.net.URI",
-          "expression": "new java.net.URI(\"http://\"+$0.host+\":\"+$0.port+$0.request.getUri())"
+          "expression": "new java.net.URI(\"http://\"+$0.host+\":\"+$0.port+$0.uri())"
         }],
         "condition": "activate(uri.getPath(),$0.method())",
         "actions": [{


### PR DESCRIPTION
…ternal request field which has changed in the vertx 3.3.x version