### PR TITLE
HWKAPM-575 | Instance table display problem when long property field

### DIFF
--- a/ui/src/main/scripts/plugins/e2e/html/details-modal.html
+++ b/ui/src/main/scripts/plugins/e2e/html/details-modal.html
@@ -67,7 +67,7 @@
           <tr dir-paginate-start="tData in filteredData = (timesData | filter:tableFilter | filter:durationRange | orderBy:sortKey:reverse) | itemsPerPage:numPerPage">
             <td>{{ tData.timestamp | date:'medium' }}</td>
             <!--<td>{{ tData.uri }}</td>-->
-            <td>
+            <td style="overflow: hidden">
               <span class="label label-default" style="margin: 1px; display: inline-block" ng-repeat="tDataProp in tData.properties">
                 {{tDataProp.name}}:{{tDataProp.value}}
               </span>

--- a/ui/src/main/scripts/plugins/e2e/html/details-modal.html
+++ b/ui/src/main/scripts/plugins/e2e/html/details-modal.html
@@ -35,7 +35,7 @@
   </div>
   <div class="row">
     <div class="col-md-12">
-      <table class="datatable table table-striped table-bordered">
+      <table class="datatable table table-striped table-bordered" style="table-layout: fixed">
         <thead>
           <tr>
             <th ng-click="sort('timestamp')">Timestamp
@@ -44,7 +44,7 @@
             <!--<th ng-click="sort('uri')">URL
               <span class="glyphicon sort-icon" ng-show="sortKey=='uri'" ng-class="{'glyphicon-chevron-up':reverse,'glyphicon-chevron-down':!reverse}"></span>
             </th>-->
-            <th ng-click="sort('properties')">Properties
+            <th ng-click="sort('properties')" style="width: 40%">Properties
               <span class="glyphicon sort-icon" ng-show="sortKey=='properties'" ng-class="{'glyphicon-chevron-up':reverse,'glyphicon-chevron-down':!reverse}"></span>
             </th>
             <th ng-click="sort('principal')">Principal
@@ -68,12 +68,14 @@
             <td>{{ tData.timestamp | date:'medium' }}</td>
             <!--<td>{{ tData.uri }}</td>-->
             <td>
-              <span class="label label-default" style="margin: 1px;" ng-repeat="tDataProp in tData.properties">{{tDataProp.name}}:{{tDataProp.value}}</span>
+              <span class="label label-default" style="margin: 1px; display: inline-block" ng-repeat="tDataProp in tData.properties">
+                {{tDataProp.name}}:{{tDataProp.value}}
+              </span>
             </td>
-            <td>{{ tData.principal }}</td>
-            <td>{{ tData.hostname }}</td>
-            <td>{{ tData.ip_address }}</td>
-            <td>{{ tData.duration }}</td>
+            <td style="word-wrap: break-word">{{ tData.principal }}</td>
+            <td style="word-wrap: break-word">{{ tData.hostname }}</td>
+            <td style="word-wrap: break-word">{{ tData.ip_address }}</td>
+            <td style="word-wrap: break-word">{{ tData.duration }}</td>
             <td class="show-details-cell" ng-click="showIVD(tData.id)"><i class="fa fa-sitemap"></i></td>
           </tr>
           <tr dir-paginate-end ng-if="selectedTx === tData.id">


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-575

![apm-instance-table-wrap](https://cloud.githubusercontent.com/assets/5618424/17739299/e968fb26-6494-11e6-8e0f-c7c59fa66097.jpg)


Review note: it the text in property span is too long it would still overflow