### PR TITLE
HWKAPM-589 | Instrumentation test framework failing due to "Address already in use"

### DIFF
--- a/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/TestScenarioRunner.java
+++ b/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/TestScenarioRunner.java
@@ -85,7 +85,7 @@ public class TestScenarioRunner {
                     ", but we expect only one of them to be defined!");
         }
 
-        log.info(String.format("Starting test scenario: %s", testScenario));
+        log.info(String.format("========================= Starting test scenario: %s", testScenario));
         int successfulTestCases = 0;
 
         for (TestCase test: testScenario.getTests()) {
@@ -101,11 +101,12 @@ public class TestScenarioRunner {
             } catch (TestFailException ex) {
                 log.severe(String.format("Test case failed: %s\n%s", ex.toString(), ex.getMessage()));
                 ex.printStackTrace();
+            } finally {
+                testEnvironmentExecutor.close();
             }
-
-            testEnvironmentExecutor.close();
         }
 
+        log.info(String.format("========================= Closing test scenario : %s", testScenario));
         return successfulTestCases;
     }
 
@@ -167,7 +168,7 @@ public class TestScenarioRunner {
             throw new TestFailException(testCase, ex);
         } finally {
             if (environmentId != null) {
-                testEnvironmentExecutor.clean(environmentId);
+                testEnvironmentExecutor.stopAndRemove(environmentId);
             }
 
             if (apmServer != null) {

--- a/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/AbstractDockerBasedEnvironment.java
+++ b/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/AbstractDockerBasedEnvironment.java
@@ -54,15 +54,7 @@ public abstract class AbstractDockerBasedEnvironment implements TestEnvironmentE
 
     @Override
     public void close() {
-        if (network != null) {
-            try {
-                log.info(String.format("Removing network: %s", network.getName()));
-                dockerClient.removeNetworkCmd(network.getId()).exec();
-            } catch (DockerException ex) {
-                log.severe(String.format("Could not remove network: %s", network));
-                throw new EnvironmentException("Could not remove network: " + network, ex);
-            }
-        }
+        removeNetwork();
 
         try {
             dockerClient.close();
@@ -78,6 +70,8 @@ public abstract class AbstractDockerBasedEnvironment implements TestEnvironmentE
      */
     @Override
     public void createNetwork() {
+        removeNetwork();
+
         String apmNetwork = apmBindAddress.substring(0, apmBindAddress.lastIndexOf(".")) + ".0/24";
 
         log.info(String.format("Creating network %s:", apmNetwork));
@@ -97,6 +91,18 @@ public abstract class AbstractDockerBasedEnvironment implements TestEnvironmentE
         } catch (DockerException ex) {
             log.severe(String.format("Could not create network: %s", createNetworkResponse));
             throw new EnvironmentException("Could not create network: " + createNetworkResponse, ex);
+        }
+    }
+
+    private void removeNetwork() {
+
+        String networkToRemove = network != null ? network.getName() : Constants.HOST_ADDED_TO_ETC_HOSTS;
+
+        try {
+            log.info(String.format("Removing network: %s", networkToRemove));
+            dockerClient.removeNetworkCmd(networkToRemove).exec();
+        } catch (DockerException ex) {
+            log.severe(String.format("Could not remove network: %s", networkToRemove));
         }
     }
 }

--- a/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/DockerComposeExecutor.java
+++ b/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/DockerComposeExecutor.java
@@ -63,7 +63,7 @@ public class DockerComposeExecutor extends AbstractDockerBasedEnvironment {
     }
 
     @Override
-    public void clean(String dockerCompose) {
+    public void stopAndRemove(String dockerCompose) {
 
         String[] command;
         try {

--- a/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/DockerImageExecutor.java
+++ b/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/DockerImageExecutor.java
@@ -37,6 +37,7 @@ import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.AccessMode;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.SELContext;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
 import com.github.dockerjava.core.command.PullImageResultCallback;
@@ -78,8 +79,10 @@ public class DockerImageExecutor extends AbstractDockerBasedEnvironment {
 
 
         CreateContainerCmd containerBuilder = dockerClient.createContainerCmd(testEnvironment.getImage())
-                .withBinds(new Bind(hostOsMountDir, new Volume(Constants.HAWKULAR_APM_AGENT_DIRECTORY), AccessMode.ro),
-                    new Bind(scenarioDirectory, new Volume(Constants.HAWKULAR_APM_TEST_DIRECTORY)))
+                .withBinds(new Bind(hostOsMountDir, new Volume(Constants.HAWKULAR_APM_AGENT_DIRECTORY),
+                                AccessMode.ro, SELContext.shared),
+                    new Bind(scenarioDirectory, new Volume(Constants.HAWKULAR_APM_TEST_DIRECTORY),
+                            AccessMode.ro, SELContext.shared))
                 .withExtraHosts(Constants.HOST_ADDED_TO_ETC_HOSTS + ":" + apmBindAddress);
 
         if (userDefinedNetwork) {
@@ -148,7 +151,7 @@ public class DockerImageExecutor extends AbstractDockerBasedEnvironment {
     }
 
     @Override
-    public void clean(String id) {
+    public void stopAndRemove(String id) {
         log.info(String.format("Cleaning environment %s", id));
         try {
             dockerClient.removeContainerCmd(id).withForce(true).exec();

--- a/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/TestEnvironmentExecutor.java
+++ b/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/TestEnvironmentExecutor.java
@@ -34,10 +34,11 @@ public interface TestEnvironmentExecutor {
     String run(TestEnvironment testEnvironment);
 
     /**
-     * Cleans and removes environment
+     * Stop and remove environment
+     *
      * @param id Id of the environment
      */
-    void clean(String id);
+    void stopAndRemove(String id);
 
     /**
      * Frees all resources for accessing/creating environment

--- a/tests/instrumentation-framework/src/test/java/org/hawkular/apm/tests/dockerized/InstrumentationTest.java
+++ b/tests/instrumentation-framework/src/test/java/org/hawkular/apm/tests/dockerized/InstrumentationTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.hawkular.apm.tests.dockerized.model.TestScenario;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -34,7 +33,6 @@ import org.junit.Test;
 public class InstrumentationTest {
 
     @Test
-    @Ignore
     public void testScenarios() throws IOException {
 
         // path to test/resources

--- a/tests/instrumentation-framework/src/test/resources/testTicketMonsterDockerCompose/docker-compose.yml
+++ b/tests/instrumentation-framework/src/test/resources/testTicketMonsterDockerCompose/docker-compose.yml
@@ -20,14 +20,13 @@ version: "2"
 services:
   ticket-monster:
     image: pavolloffay/jboss-ticket-monster
-
 # Hawkular APM specific
     extra_hosts:
       - "hawkular-apm:172.16.158.1"
     env_file: ../../apm-env-variables.properties
     volumes:
-      - .:/opt/hawkular-apm-test
-      - ../..:/opt/hawkular-apm-agent
+      - .:/opt/hawkular-apm-test:ro,z
+      - ../..:/opt/hawkular-apm-agent:ro,z
 
 # Hwakular APM specific
 networks:

--- a/tests/instrumentation-framework/src/test/resources/testTicketMonsterDockerCompose/test.json
+++ b/tests/instrumentation-framework/src/test/resources/testTicketMonsterDockerCompose/test.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ticket monster test",
+  "name": "Ticket monster test docker-compose test",
   "environment": {
     "dockerCompose": "docker-compose.yml",
     "initWaitSeconds": "20",


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-589

* enables instrumentation framework tests

Review notes: 
please run:
* `docker network rm hawkular-apm`
* `mvn clean install` in instrumentation-framework directory
* `docker network ls` -> there should not be `hawkular-apm` network 