### PR TITLE
Enhancements based on polyglot example

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/model/Constants.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/Constants.java
@@ -23,6 +23,8 @@ package org.hawkular.apm.api.model;
  */
 public class Constants {
 
+    private Constants() {}
+
     /**
      * Where trace activity begins within a client application, with the
      * invocation of a URI, any information derived from that activity
@@ -43,4 +45,48 @@ public class Constants {
      */
     public static final String DETAIL_FAULT_DESCRIPTION = "fault.description";
 
+    /**
+     * Represents database component type of
+     * {@link org.hawkular.apm.api.model.trace.Component#componentType}
+     */
+    public static final String COMPONENT_DATABASE = "Database";
+
+    /**
+     * Represents EJB component type of
+     * {@link org.hawkular.apm.api.model.trace.Component#componentType}
+     */
+    public static final String COMPONENT_EJB = "EJB";
+
+
+
+    /**
+     * Binary annotation key for HTTP URL.
+     *
+     * The entire URL, including the scheme, host and query parameters if available. See zipkinCoreConstants.
+     */
+    public static final String ZIPKIN_BIN_ANNOTATION_HTTP_URL = "http.url";
+
+    /**
+     * Binary annotation key for HTTP URL path.
+     *
+     * The absolute http path, without any query parameters. Ex. "/objects/abcd-ff"
+     * Historical note: This was commonly expressed as "http.uri" in zipkin, eventhough it was most
+     * often just a path. See zipkinCoreConstants.
+     */
+    public static final String ZIPKIN_BIN_ANNOTATION_HTTP_PATH = "http.path";
+
+    /**
+     * Binary annotation key for HTTP URL.
+     *
+     * See @{@link Constants#ZIPKIN_BIN_ANNOTATION_HTTP_PATH}.
+     *
+     * See zipkinCoreConstants
+     */
+    public static final String ZIPKIN_BIN_ANNOTATION_HTTP_URI = "http.uri";
+
+    /**
+     * The HTTP status code, when not in 2xx range. Ex. "503".  See zipkinCoreConstants.
+     */
+    public static final String ZIPKIN_BIN_ANNOTATION_HTTP_STATUS_CODE = "http.status_code";
 }
+

--- a/api/src/test/java/org/hawkular/apm/api/model/trace/TraceTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/model/trace/TraceTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.trace.CorrelationIdentifier.Scope;
 import org.junit.Test;
@@ -192,7 +193,7 @@ public class TraceTest {
         cp1.setDuration(400);
         cp1.setBaseTime(3);
         cp1.setUri("jdbc:TestDB");
-        cp1.setComponentType("Database");
+        cp1.setComponentType(Constants.COMPONENT_DATABASE);
         cp1.setOperation("select X from Y");
 
         // Third level (component) node - this represents the service proxy

--- a/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollectorTest.java
+++ b/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollectorTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.config.CollectorConfiguration;
 import org.hawkular.apm.api.model.config.ReportingLevel;
 import org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig;
@@ -651,7 +652,7 @@ public class DefaultTraceCollectorTest {
 
         // Create top level node
         collector.activate("not relevant", null);
-        collector.componentStart(null, "not relevant", "Database", "query");
+        collector.componentStart(null, "not relevant", Constants.COMPONENT_DATABASE, "query");
 
         // Cause a fragment builder to be created
         collector.activate("/test", null);
@@ -685,7 +686,7 @@ public class DefaultTraceCollectorTest {
 
         // Create top level node
         collector.activate("not relevant", null);
-        collector.componentStart(null, "not relevant", "Database", "query");
+        collector.componentStart(null, "not relevant", Constants.COMPONENT_DATABASE, "query");
 
         // Cause a fragment builder to be created
         collector.activate("/test", "op");

--- a/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/APMTracerTest.java
+++ b/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/APMTracerTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.trace.Component;
 import org.hawkular.apm.api.model.trace.Consumer;
 import org.hawkular.apm.api.model.trace.CorrelationIdentifier;
@@ -138,7 +139,7 @@ public class APMTracerTest {
 
         // Get producer invoking a remote service
         assertEquals(1, component.getNodes().size());
-        assertEquals("database", component.getComponentType());
+        assertEquals(Constants.COMPONENT_DATABASE, component.getComponentType());
         assertTrue(component.getProperties("sql").size() > 0);
         assertEquals(Producer.class, component.getNodes().get(0).getClass());
 
@@ -193,7 +194,7 @@ public class APMTracerTest {
 
         // Get producer invoking a remote service
         assertEquals(1, component.getNodes().size());
-        assertEquals("database", component.getComponentType());
+        assertEquals(Constants.COMPONENT_DATABASE, component.getComponentType());
         assertTrue(component.getProperties("sql").size() > 0);
         assertEquals(Producer.class, component.getNodes().get(0).getClass());
 
@@ -252,7 +253,7 @@ public class APMTracerTest {
 
         // Get producer invoking a remote service
         assertEquals(1, component.getNodes().size());
-        assertEquals("database", component.getComponentType());
+        assertEquals(Constants.COMPONENT_DATABASE, component.getComponentType());
         assertTrue(component.getProperties("sql").size() > 0);
         assertEquals(Producer.class, component.getNodes().get(0).getClass());
 

--- a/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/AsyncService.java
+++ b/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/AsyncService.java
@@ -19,6 +19,8 @@ package org.hawkular.apm.client.opentracing;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.hawkular.apm.api.model.Constants;
+
 import io.opentracing.APMTracer;
 import io.opentracing.References;
 import io.opentracing.Span;
@@ -44,7 +46,7 @@ public class AsyncService extends AbstractService {
         // Top level, so create Tracer and root span
         Span serverSpan = getTracer().buildSpan("Server")
                 .asChildOf(spanCtx)
-                .withTag("http.url", "http://localhost:8080/inbound?orderId=123&verbose=true")
+                .withTag(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL, "http://localhost:8080/inbound?orderId=123&verbose=true")
                 .withTag("orderId", "1243343456455")
                 .start();
 
@@ -78,7 +80,7 @@ public class AsyncService extends AbstractService {
         try (Span component2Span = getTracer().buildSpan("Component2")
                 .addReference(References.FOLLOWS_FROM, span.context())
                 .withTag("sql", "INSERT order INTO Orders")
-                .withTag("component", "database")
+                .withTag("component", Constants.COMPONENT_DATABASE)
                 .start()) {
 
             delay(500);
@@ -91,7 +93,7 @@ public class AsyncService extends AbstractService {
 
     public void callService(Span span) {
         try (Span clientSpan = getTracer().buildSpan("Client")
-                .withTag("http.url", "http://localhost:8080/outbound")
+                .withTag(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL, "http://localhost:8080/outbound")
                 .withTag(APMTracer.TRANSACTION_NAME, "AnotherTxnName")     // Should not overwrite the existing name
                 .asChildOf(span).start()) {
             Message mesg = createMessage();

--- a/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/ClientService.java
+++ b/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/ClientService.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.apm.client.opentracing;
 
+import org.hawkular.apm.api.model.Constants;
+
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
@@ -52,7 +54,7 @@ public class ClientService extends AbstractService {
 
     public void callService(Span span) {
         try (Span clientSpan = getTracer().buildSpan("Client")
-                .withTag("http.url", "http://localhost:8080/outbound")
+                .withTag(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL, "http://localhost:8080/outbound")
                 .asChildOf(span).start()) {
             Message mesg = createMessage();
             getTracer().inject(clientSpan.context(), Format.Builtin.TEXT_MAP,

--- a/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/ForkJoinService.java
+++ b/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/ForkJoinService.java
@@ -19,6 +19,8 @@ package org.hawkular.apm.client.opentracing;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
+import org.hawkular.apm.api.model.Constants;
+
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -41,7 +43,7 @@ public class ForkJoinService extends AbstractService {
         // Top level, so create Tracer and root span
         Span serverSpan = getTracer().buildSpan("Server")
                 .asChildOf(spanCtx)
-                .withTag("http.url", "http://localhost:8080/inbound?orderId=123&verbose=true")
+                .withTag(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL, "http://localhost:8080/inbound?orderId=123&verbose=true")
                 .withTag("orderId", "1243343456455")
                 .start();
 

--- a/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/SyncService.java
+++ b/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/SyncService.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.apm.client.opentracing;
 
+import org.hawkular.apm.api.model.Constants;
+
 import io.opentracing.APMTracer;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -46,7 +48,7 @@ public class SyncService extends AbstractService {
         // Top level, so create Tracer and root span
         Span serverSpan = getTracer().buildSpan("Server")
                 .asChildOf(spanCtx)
-                .withTag("http.url", "http://localhost:8080/inbound?orderId=123&verbose=true")
+                .withTag(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL, "http://localhost:8080/inbound?orderId=123&verbose=true")
                 .withTag(APMTracer.TRANSACTION_NAME, SYNC_BTXN_NAME_1)
                 .withTag(ORDER_ID_NAME, ORDER_ID_VALUE)
                 .start();
@@ -71,7 +73,7 @@ public class SyncService extends AbstractService {
         // Top level, so create Tracer and root span
         Span serverSpan = getTracer().buildSpan("Server")
                 .asChildOf(spanCtx)
-                .withTag("http.url", "http://localhost:8080/inbound?orderId=123&verbose=true")
+                .withTag(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL, "http://localhost:8080/inbound?orderId=123&verbose=true")
                 .withTag(ORDER_ID_NAME, ORDER_ID_VALUE)
                 .start();
 
@@ -93,7 +95,7 @@ public class SyncService extends AbstractService {
         try (Span componentSpan = getTracer().buildSpan("Component")
                 .asChildOf(span)
                 .withTag("sql", "INSERT order INTO Orders")
-                .withTag("component", "database")
+                .withTag("component", Constants.COMPONENT_DATABASE)
                 .start()) {
 
             delay(500);
@@ -107,7 +109,7 @@ public class SyncService extends AbstractService {
 
     public void callService(Span span) {
         try (Span clientSpan = getTracer().buildSpan("Client")
-                .withTag("http.url", "http://localhost:8080/outbound")
+                .withTag(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL, "http://localhost:8080/outbound")
                 .withTag(APMTracer.TRANSACTION_NAME, SYNC_BTXN_NAME_2)
                 .asChildOf(span).start()) {
             Message mesg = createMessage();

--- a/dist/src/main/resources/standalone/configuration/zipkin-binary-annotation-mapping.json
+++ b/dist/src/main/resources/standalone/configuration/zipkin-binary-annotation-mapping.json
@@ -4,6 +4,10 @@
     "nodeDetails": {
       "ignore": true
     }
+  },
+  "sql.query": {
+    "componentType": "Database"
   }
 }
+
 

--- a/examples/polyglot-zipkin/docker-compose.yml
+++ b/examples/polyglot-zipkin/docker-compose.yml
@@ -59,4 +59,4 @@ services:
     extra_hosts:
       - "tracing-server:${TRACING_SERVER}"
     environment:
-      - JVM_OPTS=-Dcassandra.custom_tracing_class=com.thelastpickle.cassandra.tracing.ZipkinTracing,-Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler,-DZipkinTracing.httpCollectorHost=tracing-server,-DZipkinTracing.httpCollectorPort=${TRACING_PORT}
+      - JVM_OPTS=-Dcassandra.custom_tracing_class=com.thelastpickle.cassandra.tracing.ZipkinTracing -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler -DZipkinTracing.httpCollectorHost=tracing-server -DZipkinTracing.httpCollectorPort=${TRACING_PORT}

--- a/examples/polyglot-zipkin/java-cassandra/README.adoc
+++ b/examples/polyglot-zipkin/java-cassandra/README.adoc
@@ -6,5 +6,5 @@ Cassandra with zipkin instrumentation.
 [source,shell]
 ----
 $ ./install-cassandra-zipkin.sh && docker build -t hawkular/apm-example-polyglot-zipkin-cassandra .
-$ docker run -it --rm -p 9042:9042 --add-host tracing-server:$TRACING_SERVER -e JVM_OPTS=-Dcassandra.custom_tracing_class=com.thelastpickle.cassandra.tracing.ZipkinTracing,-Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler,-DZipkinTracing.httpCollectorHost=$TRACING_SERVER,-DZipkinTracing.httpCollectorPort=$TRACING_PORT hawkular/apm-example-polyglot-zipkin-cassandra
+$ docker run -it --rm -p 9042:9042 --add-host tracing-server:$TRACING_SERVER -e JVM_OPTS="-Dcassandra.custom_tracing_class=com.thelastpickle.cassandra.tracing.ZipkinTracing -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler -DZipkinTracing.httpCollectorHost=$TRACING_SERVER -DZipkinTracing.httpCollectorPort=$TRACING_PORT" hawkular/apm-example-polyglot-zipkin-cassandra
 ----

--- a/examples/polyglot-zipkin/java-dropwizard/pom.xml
+++ b/examples/polyglot-zipkin/java-dropwizard/pom.xml
@@ -107,7 +107,7 @@
                   <mainClass>org.hawkular.apm.example.dropwizard.App</mainClass>
                 </transformer>
               </transformers>
-              <finalName>${artifactId}</finalName>
+              <finalName>${project.artifactId}</finalName>
             </configuration>
           </execution>
         </executions>

--- a/examples/polyglot-zipkin/java-wildfly-swarm/pom.xml
+++ b/examples/polyglot-zipkin/java-wildfly-swarm/pom.xml
@@ -34,7 +34,7 @@
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.zipkin.brave>3.9.1</version.io.zipkin.brave>
+    <version.io.zipkin.brave>3.10.0</version.io.zipkin.brave>
     <version.wildfly.swarm>2016.9</version.wildfly.swarm>
     <version.com.datastax.cassandra-cassandra-driver-core>3.1.0</version.com.datastax.cassandra-cassandra-driver-core>
   </properties>

--- a/server/api/src/main/java/org/hawkular/apm/server/api/utils/zipkin/BinaryAnnotationMapping.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/utils/zipkin/BinaryAnnotationMapping.java
@@ -48,7 +48,7 @@ public class BinaryAnnotationMapping {
      */
     private ExcludableProperty nodeDetails;
     /**
-     * Mapping for property {@link Trace#properties}, and its derived objects e.g.
+     * Mapping for property {@link Trace#allProperties()}, and its derived objects e.g.
      * {@link CommunicationDetails#properties},
      * {@link CompletionTime#properties},
      * {@link NodeDetails#properties},

--- a/server/api/src/main/java/org/hawkular/apm/server/api/utils/zipkin/MappingResult.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/utils/zipkin/MappingResult.java
@@ -53,7 +53,7 @@ public class MappingResult implements Serializable {
      */
     private final Map<String, String> nodeDetails;
     /**
-     * Mapping for property {@link Trace#properties}, and its derived objects e.g.
+     * Mapping for property {@link Trace#allProperties()}, and its derived objects e.g.
      * {@link CommunicationDetails#properties},
      * {@link CompletionTime#properties},
      * {@link NodeDetails#properties},

--- a/server/api/src/main/java/org/hawkular/apm/server/api/utils/zipkin/SpanHttpDeriverUtil.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/utils/zipkin/SpanHttpDeriverUtil.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.server.api.model.zipkin.BinaryAnnotation;
 import org.hawkular.apm.server.api.model.zipkin.Span;
 
@@ -40,9 +41,6 @@ public class SpanHttpDeriverUtil {
     private static final Set<String> HTTP_METHODS = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList("GET", "PUT", "POST", "DELETE", "HEAD", "TRACE", "OPTIONS")));
 
-    protected static final String ZIPKIN_HTTP_URL_KEY = "http.url";
-
-    protected static final String ZIPKIN_HTTP_CODE_KEY = "http.status_code";
 
     private SpanHttpDeriverUtil() {}
 
@@ -60,7 +58,7 @@ public class SpanHttpDeriverUtil {
         List<HttpCode> httpCodes = new ArrayList<>();
 
         for (BinaryAnnotation binaryAnnotation: binaryAnnotations) {
-            if (ZIPKIN_HTTP_CODE_KEY.equals(binaryAnnotation.getKey()) &&
+            if (Constants.ZIPKIN_BIN_ANNOTATION_HTTP_STATUS_CODE.equals(binaryAnnotation.getKey()) &&
                     binaryAnnotation.getValue() != null) {
 
                 String strHttpCode = binaryAnnotation.getValue();
@@ -120,7 +118,7 @@ public class SpanHttpDeriverUtil {
      * @return Whether HTTP based
      */
     public static boolean isHttp(Span span) {
-        return span.getBinaryAnnotation(ZIPKIN_HTTP_URL_KEY) != null;
+        return span.getBinaryAnnotation(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL) != null;
     }
 
     /**

--- a/server/api/src/test/java/org/hawkular/apm/server/api/utils/SourceInfoUtilTest.java
+++ b/server/api/src/test/java/org/hawkular/apm/server/api/utils/SourceInfoUtilTest.java
@@ -148,7 +148,7 @@ public class SourceInfoUtilTest {
     public void testGetSourceInfoNoClient() throws CacheException {
         SpanCache spanCache = new TestSpanCache();
 
-        Span serverSpan = new Span(null);
+        Span serverSpan = new Span(null, null);
         serverSpan.setId("1");
         serverSpan.setParentId("1");
 
@@ -161,18 +161,16 @@ public class SourceInfoUtilTest {
     public void testGetSourceInfoJustClient() throws CacheException {
         SpanCache spanCache = new TestSpanCache();
 
-        Span serverSpan = new Span(null);
+        Span serverSpan = new Span(null, serverAnnotations());
         serverSpan.setId("1");
         serverSpan.setParentId("1");
-        serverSpan.setAnnotations(serverAnnotations());
 
         BinaryAnnotation ba = new BinaryAnnotation();
-        ba.setKey("http.url");
+        ba.setKey(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL);
         ba.setValue("http://myhost:8080/myuri");
-        Span clientSpan = new Span(Arrays.asList(ba));
+        Span clientSpan = new Span(Arrays.asList(ba), clientAnnotations());
         clientSpan.setId("1");
         clientSpan.setParentId("1");
-        clientSpan.setAnnotations(clientAnnotations());
 
         spanCache.store(null, Arrays.asList(serverSpan, clientSpan),
                     SpanUniqueIdGenerator::toUnique);
@@ -187,18 +185,16 @@ public class SourceInfoUtilTest {
     public void testGetSourceInfoPartialClient() throws CacheException {
         SpanCache spanCache = new TestSpanCache();
 
-        Span serverSpan = new Span();
+        Span serverSpan = new Span(null, serverAnnotations());
         serverSpan.setId("2");
         serverSpan.setParentId("1");
-        serverSpan.setAnnotations(serverAnnotations());
 
         BinaryAnnotation ba = new BinaryAnnotation();
-        ba.setKey("http.url");
+        ba.setKey(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL);
         ba.setValue("http://myhost:8080/myuri");
-        Span clientSpan = new Span(Arrays.asList(ba));
+        Span clientSpan = new Span(Arrays.asList(ba), clientAnnotations());
         clientSpan.setId("2");
         clientSpan.setParentId("1");
-        clientSpan.setAnnotations(clientAnnotations());
 
         Span parentSpan = new Span();
         parentSpan.setId("1");
@@ -217,30 +213,27 @@ public class SourceInfoUtilTest {
     public void testGetSourceInfoCompleteClient() throws CacheException {
         SpanCache spanCache = new TestSpanCache();
 
-        Span serverSpan = new Span();
+        Span serverSpan = new Span(null, serverAnnotations());
         serverSpan.setId("3");
         serverSpan.setParentId("2");
-        serverSpan.setAnnotations(serverAnnotations());
 
         BinaryAnnotation ba = new BinaryAnnotation();
-        ba.setKey("http.url");
+        ba.setKey(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL);
         ba.setValue("http://myhost:8080/myuri");
-        Span clientSpan = new Span(Arrays.asList(ba));
+        Span clientSpan = new Span(Arrays.asList(ba), clientAnnotations());
         clientSpan.setId("3");
         clientSpan.setParentId("2");
-        clientSpan.setAnnotations(clientAnnotations());
 
         Span midSpan = new Span();
         midSpan.setId("2");
         midSpan.setParentId("1");
 
         BinaryAnnotation ba2 = new BinaryAnnotation();
-        ba2.setKey("http.url");
+        ba2.setKey(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL);
         ba2.setValue("http://myhost:8080/originaluri");
-        Span topServerSpan = new Span(Arrays.asList(ba2));
+        Span topServerSpan = new Span(Arrays.asList(ba2), serverAnnotations());
         topServerSpan.setId("1");
         topServerSpan.setParentId("1");
-        topServerSpan.setAnnotations(serverAnnotations());
 
         spanCache.store(null, Arrays.asList(serverSpan, clientSpan, midSpan, topServerSpan),
                     SpanUniqueIdGenerator::toUnique);
@@ -273,25 +266,16 @@ public class SourceInfoUtilTest {
 
         private Map<String, Span> cache = new HashMap<String, Span>();
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.server.api.services.Cache#get(java.lang.String, java.lang.String)
-         */
         @Override
         public Span get(String tenantId, String id) {
             return cache.get(id);
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.server.api.services.Cache#store(java.lang.String, java.util.List)
-         */
         @Override
         public void store(String tenantId, List<Span> spans) throws CacheException {
             spans.forEach(s -> cache.put(s.getId(), s));
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.server.api.services.SpanCache#getChildren(java.lang.String, java.lang.String)
-         */
         @Override
         public Set<Span> getChildren(String tenant, String id) {
             throw new UnsupportedOperationException();
@@ -302,9 +286,6 @@ public class SourceInfoUtilTest {
             throw new UnsupportedOperationException();
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.server.api.services.SpanCache#store(java.lang.String, java.util.List, java.util.function.Function)
-         */
         @Override
         public void store(String tenantId, List<Span> spans, Function<Span, String> cacheKeyEntrySupplier)
                 throws CacheException {

--- a/server/api/src/test/java/org/hawkular/apm/server/api/utils/zipkin/SpanHttpDeriverUtilTest.java
+++ b/server/api/src/test/java/org/hawkular/apm/server/api/utils/zipkin/SpanHttpDeriverUtilTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.server.api.model.zipkin.BinaryAnnotation;
 import org.junit.Assert;
 import org.junit.Test;
@@ -82,7 +83,7 @@ public class SpanHttpDeriverUtilTest {
 
     public BinaryAnnotation createHttpCodeBinaryAnnotation(String code) {
         BinaryAnnotation httpCodeBinaryAnnotation = new BinaryAnnotation();
-        httpCodeBinaryAnnotation.setKey(SpanHttpDeriverUtil.ZIPKIN_HTTP_CODE_KEY);
+        httpCodeBinaryAnnotation.setKey(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_STATUS_CODE);
         httpCodeBinaryAnnotation.setValue(code);
         return httpCodeBinaryAnnotation;
     }

--- a/server/api/src/test/java/org/hawkular/apm/server/api/utils/zipkin/SpanUniqueIdGeneratorTest.java
+++ b/server/api/src/test/java/org/hawkular/apm/server/api/utils/zipkin/SpanUniqueIdGeneratorTest.java
@@ -35,10 +35,8 @@ public class SpanUniqueIdGeneratorTest {
     public void testToUnique() {
         String originalId = "064c292e02db027c";
 
-        Span span = new Span(null);
-        span.setAnnotations(Arrays.asList());
+        Span span = new Span(null, clientAnnotations());
         span.setId(originalId);
-        span.setAnnotations(annotations());
 
         String uniqueID = SpanUniqueIdGenerator.toUnique(span);
         Assert.assertEquals(originalId + SpanUniqueIdGenerator.CLIENT_ID_SUFFIX, uniqueID);
@@ -48,10 +46,8 @@ public class SpanUniqueIdGeneratorTest {
     public void testToOriginal() {
         String originalId = "064c292e02db027c22g";
 
-        Span span = new Span(null);
-        span.setAnnotations(Arrays.asList());
+        Span span = new Span(null, clientAnnotations());
         span.setId(originalId);
-        span.setAnnotations(annotations());
 
         span.setId(span.getId() + SpanUniqueIdGenerator.CLIENT_ID_SUFFIX);
         Assert.assertEquals(originalId, SpanUniqueIdGenerator.toOriginal(span));
@@ -61,10 +57,8 @@ public class SpanUniqueIdGeneratorTest {
     public void testIllegalState() {
         String originalId = "064c292e02db027c22g";
 
-        Span span = new Span(null);
-        span.setAnnotations(Arrays.asList());
+        Span span = new Span(null, clientAnnotations());
         span.setId(originalId);
-        span.setAnnotations(annotations());
 
         String uniqueID = SpanUniqueIdGenerator.toUnique(span);
         span.setId(uniqueID);
@@ -72,7 +66,7 @@ public class SpanUniqueIdGeneratorTest {
         SpanUniqueIdGenerator.toUnique(span);
     }
 
-    private List<Annotation> annotations() {
+    private List<Annotation> clientAnnotations() {
         Annotation csAnnotation = new Annotation();
         csAnnotation.setValue("cs");
         Annotation crAnnotation = new Annotation();

--- a/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearchTest.java
+++ b/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearchTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.PropertyType;
 import org.hawkular.apm.api.model.analytics.Cardinality;
@@ -1534,28 +1535,28 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setBusinessTransaction("testapp");
         ct1_1.setTimestamp(1500);
         ct1_1.setActual(100);
-        ct1_1.setComponentType("Database");
+        ct1_1.setComponentType(Constants.COMPONENT_DATABASE);
         nds.add(ct1_1);
 
         NodeDetails ct1_2 = new NodeDetails();
         ct1_2.setBusinessTransaction("testapp");
         ct1_2.setTimestamp(1600);
         ct1_2.setActual(300);
-        ct1_2.setComponentType("Database");
+        ct1_2.setComponentType(Constants.COMPONENT_DATABASE);
         nds.add(ct1_2);
 
         NodeDetails ct1_3 = new NodeDetails();
         ct1_3.setBusinessTransaction("testapp");
         ct1_3.setTimestamp(1700);
         ct1_3.setActual(150);
-        ct1_3.setComponentType("EJB");
+        ct1_3.setComponentType(Constants.COMPONENT_EJB);
         nds.add(ct1_3);
 
         NodeDetails ct2 = new NodeDetails();
         ct2.setBusinessTransaction("testapp");
         ct2.setTimestamp(2100);
         ct2.setActual(500);
-        ct2.setComponentType("Database");
+        ct2.setComponentType(Constants.COMPONENT_DATABASE);
         nds.add(ct2);
 
         try {
@@ -1582,16 +1583,16 @@ public class AnalyticsServiceElasticsearchTest {
         assertEquals(2, stats.get(0).getComponentTypes().size());
         assertEquals(1, stats.get(1).getComponentTypes().size());
 
-        assertTrue(stats.get(0).getComponentTypes().containsKey("Database"));
-        assertTrue(stats.get(0).getComponentTypes().containsKey("EJB"));
-        assertTrue(stats.get(1).getComponentTypes().containsKey("Database"));
+        assertTrue(stats.get(0).getComponentTypes().containsKey(Constants.COMPONENT_DATABASE));
+        assertTrue(stats.get(0).getComponentTypes().containsKey(Constants.COMPONENT_EJB));
+        assertTrue(stats.get(1).getComponentTypes().containsKey(Constants.COMPONENT_DATABASE));
 
-        assertTrue(stats.get(0).getComponentTypes().get("Database").getDuration() == 200);
-        assertTrue(stats.get(0).getComponentTypes().get("Database").getCount() == 2);
-        assertTrue(stats.get(0).getComponentTypes().get("EJB").getDuration() == 150);
-        assertTrue(stats.get(0).getComponentTypes().get("EJB").getCount() == 1);
-        assertTrue(stats.get(1).getComponentTypes().get("Database").getDuration() == 500);
-        assertTrue(stats.get(1).getComponentTypes().get("Database").getCount() == 1);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_DATABASE).getDuration() == 200);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_DATABASE).getCount() == 2);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_EJB).getDuration() == 150);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_EJB).getCount() == 1);
+        assertTrue(stats.get(1).getComponentTypes().get(Constants.COMPONENT_DATABASE).getDuration() == 500);
+        assertTrue(stats.get(1).getComponentTypes().get(Constants.COMPONENT_DATABASE).getCount() == 1);
     }
 
     @Test
@@ -1602,7 +1603,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setBusinessTransaction("testapp");
         ct1_1.setTimestamp(1500);
         ct1_1.setActual(100);
-        ct1_1.setComponentType("Database");
+        ct1_1.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_1.setPrincipal("p1");
         nds.add(ct1_1);
 
@@ -1610,7 +1611,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setBusinessTransaction("testapp");
         ct1_2.setTimestamp(1600);
         ct1_2.setActual(300);
-        ct1_2.setComponentType("Database");
+        ct1_2.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_2.setPrincipal("p1");
         nds.add(ct1_2);
 
@@ -1618,7 +1619,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_3.setBusinessTransaction("testapp");
         ct1_3.setTimestamp(1700);
         ct1_3.setActual(150);
-        ct1_3.setComponentType("EJB");
+        ct1_3.setComponentType(Constants.COMPONENT_EJB);
         ct1_3.setPrincipal("p1");
         nds.add(ct1_3);
 
@@ -1626,7 +1627,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct2.setBusinessTransaction("testapp");
         ct2.setTimestamp(2100);
         ct2.setActual(500);
-        ct2.setComponentType("Database");
+        ct2.setComponentType(Constants.COMPONENT_DATABASE);
         ct2.setPrincipal("p2");
         nds.add(ct2);
 
@@ -1651,13 +1652,13 @@ public class AnalyticsServiceElasticsearchTest {
 
         assertEquals(2, stats.get(0).getComponentTypes().size());
 
-        assertTrue(stats.get(0).getComponentTypes().containsKey("Database"));
-        assertTrue(stats.get(0).getComponentTypes().containsKey("EJB"));
+        assertTrue(stats.get(0).getComponentTypes().containsKey(Constants.COMPONENT_DATABASE));
+        assertTrue(stats.get(0).getComponentTypes().containsKey(Constants.COMPONENT_EJB));
 
-        assertTrue(stats.get(0).getComponentTypes().get("Database").getDuration() == 200);
-        assertTrue(stats.get(0).getComponentTypes().get("Database").getCount() == 2);
-        assertTrue(stats.get(0).getComponentTypes().get("EJB").getDuration() == 150);
-        assertTrue(stats.get(0).getComponentTypes().get("EJB").getCount() == 1);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_DATABASE).getDuration() == 200);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_DATABASE).getCount() == 2);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_EJB).getDuration() == 150);
+        assertTrue(stats.get(0).getComponentTypes().get(Constants.COMPONENT_EJB).getCount() == 1);
     }
 
     @Test
@@ -1679,7 +1680,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setActual(100);
         ct1_1.setElapsed(200);
         ct1_1.setType(NodeType.Component);
-        ct1_1.setComponentType("Database");
+        ct1_1.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_1.setUri("jdbc");
         nds.add(ct1_1);
 
@@ -1689,7 +1690,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setActual(300);
         ct1_2.setElapsed(600);
         ct1_2.setType(NodeType.Component);
-        ct1_2.setComponentType("Database");
+        ct1_2.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_2.setUri("jdbc");
         nds.add(ct1_2);
 
@@ -1699,7 +1700,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_3.setActual(150);
         ct1_3.setElapsed(300);
         ct1_3.setType(NodeType.Component);
-        ct1_3.setComponentType("EJB");
+        ct1_3.setComponentType(Constants.COMPONENT_EJB);
         ct1_3.setUri("BookingService");
         ct1_3.setOperation("createBooking");
         nds.add(ct1_3);
@@ -1724,9 +1725,9 @@ public class AnalyticsServiceElasticsearchTest {
         NodeSummaryStatistics consumerstat = null;
 
         for (NodeSummaryStatistics nss : stats) {
-            if (nss.getComponentType().equalsIgnoreCase("Database")) {
+            if (nss.getComponentType().equalsIgnoreCase(Constants.COMPONENT_DATABASE)) {
                 dbstat = nss;
-            } else if (nss.getComponentType().equalsIgnoreCase("EJB")) {
+            } else if (nss.getComponentType().equalsIgnoreCase(Constants.COMPONENT_EJB)) {
                 ejbstat = nss;
             } else if (nss.getComponentType().equalsIgnoreCase("Consumer")) {
                 consumerstat = nss;
@@ -1772,7 +1773,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setActual(100);
         ct1_1.setElapsed(200);
         ct1_1.setType(NodeType.Component);
-        ct1_1.setComponentType("Database");
+        ct1_1.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_1.setUri("jdbc");
         ct1_1.setHostName("hostA");
         nds.add(ct1_1);
@@ -1783,7 +1784,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setActual(300);
         ct1_2.setElapsed(600);
         ct1_2.setType(NodeType.Component);
-        ct1_2.setComponentType("Database");
+        ct1_2.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_2.setUri("jdbc");
         ct1_2.setHostName("hostB");
         nds.add(ct1_2);
@@ -1794,7 +1795,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_3.setActual(150);
         ct1_3.setElapsed(300);
         ct1_3.setType(NodeType.Component);
-        ct1_3.setComponentType("EJB");
+        ct1_3.setComponentType(Constants.COMPONENT_EJB);
         ct1_3.setUri("BookingService");
         ct1_3.setOperation("createBooking");
         ct1_3.setHostName("hostB");
@@ -1820,22 +1821,22 @@ public class AnalyticsServiceElasticsearchTest {
         NodeSummaryStatistics consumerstat = null;
 
         for (NodeSummaryStatistics nss : stats) {
-            if (nss.getComponentType().equalsIgnoreCase("Database")) {
+            if (nss.getComponentType().equalsIgnoreCase(Constants.COMPONENT_DATABASE)) {
                 dbstat = nss;
-            } else if (nss.getComponentType().equalsIgnoreCase("EJB")) {
+            } else if (nss.getComponentType().equalsIgnoreCase(Constants.COMPONENT_EJB)) {
                 ejbstat = nss;
             } else if (nss.getComponentType().equalsIgnoreCase("Consumer")) {
                 consumerstat = nss;
             }
         }
 
-        assertTrue(dbstat.getComponentType().equalsIgnoreCase("Database"));
+        assertTrue(dbstat.getComponentType().equalsIgnoreCase(Constants.COMPONENT_DATABASE));
         assertTrue(dbstat.getUri().equalsIgnoreCase("jdbc"));
         assertNull(dbstat.getOperation());
         assertEquals(2, dbstat.getCount());
         assertTrue(dbstat.getActual() == 200.0);
         assertTrue(dbstat.getElapsed() == 400.0);
-        assertTrue(ejbstat.getComponentType().equalsIgnoreCase("EJB"));
+        assertTrue(ejbstat.getComponentType().equalsIgnoreCase(Constants.COMPONENT_EJB));
         assertTrue(ejbstat.getUri().equalsIgnoreCase("BookingService"));
         assertTrue(ejbstat.getOperation().equalsIgnoreCase("createBooking"));
         assertEquals(1, ejbstat.getCount());
@@ -1869,7 +1870,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setActual(100);
         ct1_1.setElapsed(200);
         ct1_1.setType(NodeType.Component);
-        ct1_1.setComponentType("Database");
+        ct1_1.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_1.setUri("jdbc");
         ct1_1.setHostName("hostA");
         nds.add(ct1_1);
@@ -1880,7 +1881,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setActual(300);
         ct1_2.setElapsed(600);
         ct1_2.setType(NodeType.Component);
-        ct1_2.setComponentType("Database");
+        ct1_2.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_2.setUri("jdbc");
         ct1_2.setHostName("hostB");
         nds.add(ct1_2);
@@ -1891,7 +1892,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_3.setActual(150);
         ct1_3.setElapsed(300);
         ct1_3.setType(NodeType.Component);
-        ct1_3.setComponentType("EJB");
+        ct1_3.setComponentType(Constants.COMPONENT_EJB);
         ct1_3.setUri("BookingService");
         ct1_3.setOperation("createBooking");
         ct1_3.setHostName("hostB");
@@ -1916,14 +1917,14 @@ public class AnalyticsServiceElasticsearchTest {
         NodeSummaryStatistics consumerstat = null;
 
         for (NodeSummaryStatistics nss : stats) {
-            if (nss.getComponentType().equalsIgnoreCase("Database")) {
+            if (nss.getComponentType().equalsIgnoreCase(Constants.COMPONENT_DATABASE)) {
                 dbstat = nss;
             } else if (nss.getComponentType().equalsIgnoreCase("Consumer")) {
                 consumerstat = nss;
             }
         }
 
-        assertTrue(dbstat.getComponentType().equalsIgnoreCase("Database"));
+        assertTrue(dbstat.getComponentType().equalsIgnoreCase(Constants.COMPONENT_DATABASE));
         assertTrue(dbstat.getUri().equalsIgnoreCase("jdbc"));
         assertNull(dbstat.getOperation());
         assertEquals(1, dbstat.getCount());
@@ -1958,7 +1959,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setActual(100);
         ct1_1.setElapsed(200);
         ct1_1.setType(NodeType.Component);
-        ct1_1.setComponentType("Database");
+        ct1_1.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_1.setUri("jdbc");
         ct1_1.setHostName("hostA");
         ct1_1.setPrincipal("p1");
@@ -1970,7 +1971,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setActual(300);
         ct1_2.setElapsed(600);
         ct1_2.setType(NodeType.Component);
-        ct1_2.setComponentType("Database");
+        ct1_2.setComponentType(Constants.COMPONENT_DATABASE);
         ct1_2.setUri("jdbc");
         ct1_2.setHostName("hostB");
         ct1_2.setPrincipal("p2");
@@ -1982,7 +1983,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_3.setActual(150);
         ct1_3.setElapsed(300);
         ct1_3.setType(NodeType.Component);
-        ct1_3.setComponentType("EJB");
+        ct1_3.setComponentType(Constants.COMPONENT_EJB);
         ct1_3.setUri("BookingService");
         ct1_3.setOperation("createBooking");
         ct1_3.setHostName("hostB");
@@ -2008,14 +2009,14 @@ public class AnalyticsServiceElasticsearchTest {
         NodeSummaryStatistics consumerstat = null;
 
         for (NodeSummaryStatistics nss : stats) {
-            if (nss.getComponentType().equalsIgnoreCase("Database")) {
+            if (nss.getComponentType().equalsIgnoreCase(Constants.COMPONENT_DATABASE)) {
                 dbstat = nss;
             } else if (nss.getComponentType().equalsIgnoreCase("Consumer")) {
                 consumerstat = nss;
             }
         }
 
-        assertTrue(dbstat.getComponentType().equalsIgnoreCase("Database"));
+        assertTrue(dbstat.getComponentType().equalsIgnoreCase(Constants.COMPONENT_DATABASE));
         assertTrue(dbstat.getUri().equalsIgnoreCase("jdbc"));
         assertNull(dbstat.getOperation());
         assertEquals(1, dbstat.getCount());

--- a/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/SpanServiceElasticsearchTest.java
+++ b/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/SpanServiceElasticsearchTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.trace.Component;
 import org.hawkular.apm.api.model.trace.Consumer;
 import org.hawkular.apm.api.model.trace.InteractionNode;
@@ -83,7 +84,7 @@ public class SpanServiceElasticsearchTest {
         binaryAnnotation.setKey("foo key");
         binaryAnnotation.setType(AnnotationType.I64);
 
-        Span span = new Span(Arrays.asList(binaryAnnotation));
+        Span span = new Span(Arrays.asList(binaryAnnotation), Arrays.asList(annotation));
         span.setId("id");
         span.setTraceId("traceId");
         span.setParentId("parentId");
@@ -91,7 +92,6 @@ public class SpanServiceElasticsearchTest {
         span.setDebug(true);
         span.setTimestamp(1234456L);
         span.setDuration(55468L);
-        span.setAnnotations(Arrays.asList(annotation));
 
         storeAndWait(null, Collections.singletonList(span));
         Span spanFromDb = spanService.getSpan(null, span.getId());
@@ -118,7 +118,7 @@ public class SpanServiceElasticsearchTest {
         binaryAnnotation.setKey("foo key");
         binaryAnnotation.setType(AnnotationType.I64);
 
-        Span span = new Span(Arrays.asList(binaryAnnotation));
+        Span span = new Span(Arrays.asList(binaryAnnotation), Arrays.asList(annotation));
         span.setId("id1");
         span.setTraceId("traceId");
         span.setParentId("parent");
@@ -126,7 +126,6 @@ public class SpanServiceElasticsearchTest {
         span.setDebug(true);
         span.setTimestamp(1234456L);
         span.setDuration(55468L);
-        span.setAnnotations(Arrays.asList(annotation));
 
         storeAndWait(null, Collections.singletonList(span));
 
@@ -145,10 +144,9 @@ public class SpanServiceElasticsearchTest {
     public void testStoreWithIdSupplier() throws StoreException, InterruptedException {
         final String clientIdsuffix = "-client";
 
-        Span clientSpan = new Span();
+        Span clientSpan = new Span(null, clientAnnotations());
         clientSpan.setId("foo");
         clientSpan.setDuration(111);
-        clientSpan.setAnnotations(clientAnnotations());
 
         storeAndWait(null, Collections.singletonList(clientSpan), x -> x.getId() + clientIdsuffix);
 
@@ -186,34 +184,29 @@ public class SpanServiceElasticsearchTest {
 
     @Test
     public void testGetTraceFragmentRootServerSpan() throws StoreException, InterruptedException {
-        Span rootServerSpan = new Span();
+        Span rootServerSpan = new Span(null, serverAnnotations());
         rootServerSpan.setId("root");
         rootServerSpan.setTraceId("root");
-        rootServerSpan.setAnnotations(serverAnnotations());
 
-        Span clientDescendant = new Span();
+        Span clientDescendant = new Span(null, clientAnnotations());
         clientDescendant.setId("descendant");
         clientDescendant.setParentId("root");
         clientDescendant.setTraceId("root");
-        clientDescendant.setAnnotations(clientAnnotations());
 
-        Span clientDescendant2 = new Span();
+        Span clientDescendant2 = new Span(null, clientAnnotations());
         clientDescendant2.setId("descendant2");
         clientDescendant2.setParentId("root");
         clientDescendant2.setTraceId("root");
-        clientDescendant2.setAnnotations(clientAnnotations());
 
-        Span serverDescendantOfDescendant2 = new Span();
+        Span serverDescendantOfDescendant2 = new Span(null, serverAnnotations());
         serverDescendantOfDescendant2.setId("descendant2");
         serverDescendantOfDescendant2.setParentId("root");
         serverDescendantOfDescendant2.setTraceId("root");
-        serverDescendantOfDescendant2.setAnnotations(serverAnnotations());
 
-        Span serverDescendantOfDescendant = new Span();
+        Span serverDescendantOfDescendant = new Span(null, serverAnnotations());
         serverDescendantOfDescendant.setId("descendant");
         serverDescendantOfDescendant.setParentId("root");
         serverDescendantOfDescendant.setTraceId("root");
-        serverDescendantOfDescendant.setAnnotations(serverAnnotations());
 
         storeAndWait(null, Arrays.asList(rootServerSpan,
                 clientDescendant,
@@ -249,28 +242,24 @@ public class SpanServiceElasticsearchTest {
 
     @Test
     public void testGetTraceFragmentClientRoot() throws StoreException, InterruptedException {
-        Span rootClientSpan = new Span();
+        Span rootClientSpan = new Span(null, clientAnnotations());
         rootClientSpan.setId("root");
         rootClientSpan.setTraceId("root");
         rootClientSpan.setName("rootClientSpan");
-        rootClientSpan.setAnnotations(clientAnnotations());
 
-        Span serverSpan = new Span();
+        Span serverSpan = new Span(null, serverAnnotations());
         serverSpan.setId("root");
         serverSpan.setTraceId("root");
-        serverSpan.setAnnotations(serverAnnotations());
 
-        Span clientSpanDescendantRoot = new Span();
-        serverSpan.setId("root2");
-        serverSpan.setParentId("root");
-        serverSpan.setTraceId("root");
-        serverSpan.setAnnotations(clientAnnotations());
+        Span clientSpanDescendantRoot = new Span(null, clientAnnotations());
+        clientSpanDescendantRoot.setId("root2");
+        clientSpanDescendantRoot.setParentId("root");
+        clientSpanDescendantRoot.setTraceId("root");
 
-        Span serverSpanOfClientDescendantRoot = new Span();
+        Span serverSpanOfClientDescendantRoot = new Span(null, serverAnnotations());
         serverSpanOfClientDescendantRoot.setId("root2");
         serverSpanOfClientDescendantRoot.setParentId("root");
         serverSpanOfClientDescendantRoot.setTraceId("root");
-        serverSpanOfClientDescendantRoot.setAnnotations(serverAnnotations());
 
         storeAndWait(null, Arrays.asList(
                 rootClientSpan,
@@ -292,40 +281,35 @@ public class SpanServiceElasticsearchTest {
 
     @Test
     public void testGetTraceFragmentComponent() throws StoreException, InterruptedException {
-        Span rootServerSpan = new Span();
+        Span rootServerSpan = new Span(null, serverAnnotations());
         rootServerSpan.setId("root");
         rootServerSpan.setTraceId("root");
-        rootServerSpan.setAnnotations(serverAnnotations());
 
         Span componentSpan = new Span();
         componentSpan.setId("component");
         componentSpan.setParentId("root");
         componentSpan.setTraceId("root");
-        componentSpan.setName("ejb");
+        componentSpan.setName(Constants.COMPONENT_EJB);
 
-        Span clientComponentSpan = new Span();
+        Span clientComponentSpan = new Span(null, clientAnnotations());
         clientComponentSpan.setId("clientComponent");
         clientComponentSpan.setParentId("component");
         clientComponentSpan.setTraceId("root");
-        clientComponentSpan.setAnnotations(clientAnnotations());
 
-        Span clientComponentSpan2 = new Span();
+        Span clientComponentSpan2 = new Span(null, clientAnnotations());
         clientComponentSpan2.setId("clientComponent2");
         clientComponentSpan2.setParentId("component");
         clientComponentSpan2.setTraceId("root");
-        clientComponentSpan2.setAnnotations(clientAnnotations());
 
-        Span descendant = new Span();
+        Span descendant = new Span(null, clientAnnotations());
         descendant.setId("descendant");
         descendant.setParentId("root");
         descendant.setTraceId("root");
-        descendant.setAnnotations(clientAnnotations());
 
-        Span descendantServer = new Span();
+        Span descendantServer = new Span(null, serverAnnotations());
         descendantServer.setId("descendant");
         descendantServer.setParentId("root");
         descendantServer.setTraceId("root");
-        descendantServer.setAnnotations(serverAnnotations());
 
         storeAndWait(null, Arrays.asList(
                 rootServerSpan,
@@ -364,34 +348,29 @@ public class SpanServiceElasticsearchTest {
 
     @Test
     public void testGetEndToEndTrace() throws StoreException, InterruptedException {
-        Span rootServerSpan = new Span();
+        Span rootServerSpan = new Span(null, serverAnnotations());
         rootServerSpan.setId("root");
         rootServerSpan.setTraceId("root");
-        rootServerSpan.setAnnotations(serverAnnotations());
 
-        Span clientDescendant = new Span();
+        Span clientDescendant = new Span(null, clientAnnotations());
         clientDescendant.setId("descendant");
         clientDescendant.setParentId("root");
         clientDescendant.setTraceId("root");
-        clientDescendant.setAnnotations(clientAnnotations());
 
-        Span clientDescendant2 = new Span();
+        Span clientDescendant2 = new Span(null, clientAnnotations());
         clientDescendant2.setId("descendant2");
         clientDescendant2.setParentId("root");
         clientDescendant2.setTraceId("root");
-        clientDescendant2.setAnnotations(clientAnnotations());
 
-        Span serverDescendantOfDescendant2 = new Span();
+        Span serverDescendantOfDescendant2 = new Span(null, serverAnnotations());
         serverDescendantOfDescendant2.setId("descendant2");
         serverDescendantOfDescendant2.setParentId("root");
         serverDescendantOfDescendant2.setTraceId("root");
-        serverDescendantOfDescendant2.setAnnotations(serverAnnotations());
 
-        Span serverDescendantOfDescendant = new Span();
+        Span serverDescendantOfDescendant = new Span(null, serverAnnotations());
         serverDescendantOfDescendant.setId("descendant");
         serverDescendantOfDescendant.setParentId("root");
         serverDescendantOfDescendant.setTraceId("root");
-        serverDescendantOfDescendant.setAnnotations(serverAnnotations());
 
         storeAndWait(null, Arrays.asList(rootServerSpan,
                 clientDescendant,
@@ -439,39 +418,33 @@ public class SpanServiceElasticsearchTest {
 
     @Test
     public void testGetEndToEndTraceClientRoot() throws StoreException, InterruptedException {
-        Span rootClientSpan = new Span();
+        Span rootClientSpan = new Span(null, clientAnnotations());
         rootClientSpan.setId("root");
         rootClientSpan.setTraceId("root");
-        rootClientSpan.setAnnotations(clientAnnotations());
 
-        Span rootServerSpan = new Span();
+        Span rootServerSpan = new Span(null, serverAnnotations());
         rootServerSpan.setId("root");
         rootServerSpan.setTraceId("root");
-        rootServerSpan.setAnnotations(serverAnnotations());
 
-        Span clientDescendant = new Span();
+        Span clientDescendant = new Span(null, clientAnnotations());
         clientDescendant.setId("descendant");
         clientDescendant.setParentId("root");
         clientDescendant.setTraceId("root");
-        clientDescendant.setAnnotations(clientAnnotations());
 
-        Span clientDescendant2 = new Span();
+        Span clientDescendant2 = new Span(null, clientAnnotations());
         clientDescendant2.setId("descendant2");
         clientDescendant2.setParentId("root");
         clientDescendant2.setTraceId("root");
-        clientDescendant2.setAnnotations(clientAnnotations());
 
-        Span serverDescendantOfDescendant2 = new Span();
+        Span serverDescendantOfDescendant2 = new Span(null, serverAnnotations());
         serverDescendantOfDescendant2.setId("descendant2");
         serverDescendantOfDescendant2.setParentId("root");
         serverDescendantOfDescendant2.setTraceId("root");
-        serverDescendantOfDescendant2.setAnnotations(serverAnnotations());
 
-        Span serverDescendantOfDescendant = new Span();
+        Span serverDescendantOfDescendant = new Span(null, serverAnnotations());
         serverDescendantOfDescendant.setId("descendant");
         serverDescendantOfDescendant.setParentId("root");
         serverDescendantOfDescendant.setTraceId("root");
-        serverDescendantOfDescendant.setAnnotations(serverAnnotations());
 
         storeAndWait(null, Arrays.asList(rootClientSpan,
                 rootServerSpan,
@@ -561,11 +534,11 @@ public class SpanServiceElasticsearchTest {
     }
 
     private List<Annotation> serverAnnotations() {
-        Annotation csAnnotation = new Annotation();
-        csAnnotation.setValue("sr");
-        Annotation crAnnotation = new Annotation();
-        crAnnotation.setValue("ss");
+        Annotation srAnnotation = new Annotation();
+        srAnnotation.setValue("sr");
+        Annotation ssAnnotation = new Annotation();
+        ssAnnotation.setValue("ss");
 
-        return Collections.unmodifiableList(Arrays.asList(csAnnotation, crAnnotation));
+        return Collections.unmodifiableList(Arrays.asList(srAnnotation, ssAnnotation));
     }
 }

--- a/server/infinispan/src/main/java/org/hawkular/apm/server/infinispan/InfinispanSpanCache.java
+++ b/server/infinispan/src/main/java/org/hawkular/apm/server/infinispan/InfinispanSpanCache.java
@@ -35,7 +35,6 @@ import org.hawkular.apm.server.api.services.SpanCache;
 import org.hawkular.apm.server.api.utils.zipkin.SpanUniqueIdGenerator;
 import org.infinispan.Cache;
 import org.infinispan.manager.CacheContainer;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.logging.Logger;
 
 /**
@@ -128,7 +127,6 @@ public class InfinispanSpanCache implements SpanCache, ServiceLifecycle {
             }
         }
 
-        EmbeddedCacheManager embeddedCacheManager;
         if (cacheContainer != null) {
             spansCache.endBatch(true);
             childrenCache.endBatch(true);

--- a/server/infinispan/src/test/java/org/hawkular/apm/server/infinispan/InfinispanSpanCacheTest.java
+++ b/server/infinispan/src/test/java/org/hawkular/apm/server/infinispan/InfinispanSpanCacheTest.java
@@ -66,16 +66,14 @@ public class InfinispanSpanCacheTest extends AbstractInfinispanTest {
         parent.setId("parent");
         storeOne(spanCache, parent);
 
-        Span childServerSpan = new Span();
+        Span childServerSpan = new Span(null, serverAnnotations());
         childServerSpan.setId("child1");
         childServerSpan.setParentId("parent");
-        childServerSpan.setAnnotations(serverAnnotations());
         storeOne(spanCache, childServerSpan);
 
-        Span childClientSpan = new Span();
+        Span childClientSpan = new Span(null, clientAnnotations());
         childClientSpan.setId("child2");
         childClientSpan.setParentId("parent");
-        childClientSpan.setAnnotations(clientAnnotations());
         storeOne(spanCache, childClientSpan);
 
         Span childClientSpan2 = new Span();
@@ -94,9 +92,8 @@ public class InfinispanSpanCacheTest extends AbstractInfinispanTest {
 
     @Test
     public void testCacheKeyEntryGenerator() throws CacheException {
-        Span span = new Span();
+        Span span = new Span(null, clientAnnotations());
         span.setId("parent");
-        span.setAnnotations(clientAnnotations());
 
         spanCache.store(null, Arrays.asList(span), x -> x.getId() + "-foo");
         Assert.assertEquals(span, spanCache.get(null, span.getId() + "-foo"));

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/CommunicationDetailsDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/CommunicationDetailsDeriverMDB.java
@@ -24,6 +24,7 @@ import javax.jms.MessageListener;
 
 import org.hawkular.apm.api.model.events.CommunicationDetails;
 import org.hawkular.apm.server.api.model.zipkin.Span;
+import org.hawkular.apm.server.api.services.SpanCache;
 import org.hawkular.apm.server.jms.CommunicationDetailsPublisherJMS;
 import org.hawkular.apm.server.jms.RetryCapableMDB;
 import org.hawkular.apm.server.processor.zipkin.CommunicationDetailsDeriver;
@@ -53,7 +54,7 @@ public class CommunicationDetailsDeriverMDB extends RetryCapableMDB<Span, Commun
     private CommunicationDetailsPublisherJMS communicationDetailsPublisher;
 
     @Inject
-    private CommunicationDetailsDeriver communicationDetailsDeriver;
+    private SpanCache spanCache;
 
     /**  */
     public static final String SUBSCRIBER = "SpanCommunicationDetailsDeriver";
@@ -64,7 +65,7 @@ public class CommunicationDetailsDeriverMDB extends RetryCapableMDB<Span, Commun
 
     @PostConstruct
     public void init() {
-        setProcessor(communicationDetailsDeriver);
+        setProcessor(new CommunicationDetailsDeriver(spanCache));
         setRetryPublisher(spanPublisher);
         setPublisher(communicationDetailsPublisher);
         setTypeReference(new TypeReference<java.util.List<Span>>() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/FragmentCompletionTimeDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/FragmentCompletionTimeDeriverMDB.java
@@ -24,6 +24,7 @@ import javax.jms.MessageListener;
 
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.server.api.model.zipkin.Span;
+import org.hawkular.apm.server.api.services.SpanCache;
 import org.hawkular.apm.server.jms.FragmentCompletionTimePublisherJMS;
 import org.hawkular.apm.server.jms.RetryCapableMDB;
 import org.hawkular.apm.server.processor.zipkin.FragmentCompletionTimeDeriver;
@@ -51,6 +52,9 @@ public class FragmentCompletionTimeDeriverMDB extends RetryCapableMDB<Span, Comp
     private SpanPublisherJMS spanPublisher;
 
     @Inject
+    private SpanCache spanCache;
+
+    @Inject
     private FragmentCompletionTimePublisherJMS fragmentCompletionTimePublisher;
 
     /**  */
@@ -62,7 +66,7 @@ public class FragmentCompletionTimeDeriverMDB extends RetryCapableMDB<Span, Comp
 
     @PostConstruct
     public void init() {
-        setProcessor(new FragmentCompletionTimeDeriver());
+        setProcessor(new FragmentCompletionTimeDeriver(spanCache));
         setRetryPublisher(spanPublisher);
         setPublisher(fragmentCompletionTimePublisher);
         setTypeReference(new TypeReference<java.util.List<Span>>() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/comletiontime/CompletionTimeProcessingMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/comletiontime/CompletionTimeProcessingMDB.java
@@ -25,6 +25,7 @@ import javax.ejb.MessageDriven;
 import javax.inject.Inject;
 import javax.jms.MessageListener;
 
+import org.hawkular.apm.server.api.services.SpanCache;
 import org.hawkular.apm.server.jms.RetryCapableMDB;
 import org.hawkular.apm.server.processor.zipkin.CompletionTimeProcessing;
 import org.hawkular.apm.server.processor.zipkin.CompletionTimeProcessingDeriver;
@@ -52,7 +53,7 @@ public class CompletionTimeProcessingMDB extends RetryCapableMDB<CompletionTimeP
     public static final String SUBSCRIBER = "SpanTraceCompletionTimeProcessingDeriver";
 
     @Inject
-    private CompletionTimeProcessingDeriver completionTimeProcessingDeriver;
+    private SpanCache spanCache;
 
     @Inject
     private CompletionTimeProcessingPublisher traceCompletionTimePublisher;
@@ -66,7 +67,7 @@ public class CompletionTimeProcessingMDB extends RetryCapableMDB<CompletionTimeP
 
     @PostConstruct
     public void init() {
-        setProcessor(completionTimeProcessingDeriver);
+        setProcessor(new CompletionTimeProcessingDeriver(spanCache));
         setRetryPublisher(processingPublisherJMS);
         setPublisher(traceCompletionTimePublisher);
         setTypeReference(new TypeReference<List<CompletionTimeProcessing>>() {

--- a/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/FragmentCompletionTimeDeriver.java
+++ b/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/FragmentCompletionTimeDeriver.java
@@ -16,14 +16,15 @@
  */
 package org.hawkular.apm.server.processor.zipkin;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.List;
 
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.server.api.model.zipkin.Span;
+import org.hawkular.apm.server.api.services.SpanCache;
 import org.hawkular.apm.server.api.task.AbstractProcessor;
 import org.hawkular.apm.server.api.task.RetryAttemptException;
 import org.hawkular.apm.server.api.utils.zipkin.SpanUniqueIdGenerator;
+import org.jboss.logging.Logger;
 
 /**
  * This class represents the zipkin fragment completion time deriver.
@@ -32,38 +33,58 @@ import org.hawkular.apm.server.api.utils.zipkin.SpanUniqueIdGenerator;
  */
 public class FragmentCompletionTimeDeriver extends AbstractProcessor<Span, CompletionTime> {
 
-    private static final Logger log = Logger.getLogger(FragmentCompletionTimeDeriver.class.getName());
+    private static final Logger log = Logger.getLogger(FragmentCompletionTimeDeriver.class);
+
+    private final SpanCache spanCache;
+
 
     /**
      * The default constructor.
      */
-    public FragmentCompletionTimeDeriver() {
+    public FragmentCompletionTimeDeriver(SpanCache spanCache) {
         super(ProcessorType.OneToOne);
+        this.spanCache = spanCache;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
-     */
     @Override
-    public CompletionTime processOneToOne(String tenantId, Span item) throws RetryAttemptException {
+    public CompletionTime processOneToOne(String tenantId, Span span) throws RetryAttemptException {
 
-        if ((item.clientSpan() && item.getParentId() == null)
-                || item.serverSpan()) {
+        if (span.getParentId() == null || span.serverSpan()) {
+            CompletionTime ct = CompletionTimeUtil.spanToCompletionTime(spanCache, span);
+            if (ct == null) {
+                return null;
+            }
 
-            CompletionTime ct = CompletionTimeUtil.spanToCompletionTime(item);
+            /**
+             * Client span can contain URL.
+             * If there is not URL after retry attempts then do not derive completion time.
+             */
+            if (span.serverSpan() && ct.getUri() == null) {
+                // stop retries if the client span was found and url is still missing
+                if (spanCache.get(null, SpanUniqueIdGenerator.getClientId(span.getId())) != null) {
+                    log.warnf("NO URL, span = %s", span);
+                    return null;
+                }
 
-            if (item.clientSpan()) {
+                log.debugf("Server span does not contain URL, waiting for client span, span id=%s", span.getId());
+                throw new RetryAttemptException("URL is null, span id = " + span.getId());
+            }
+
+            if (span.clientSpan()) {
                 // To differentiate from the server fragment
-                ct.setId(SpanUniqueIdGenerator.toUnique(item));
+                ct.setId(SpanUniqueIdGenerator.toUnique(span));
             }
 
-            if (log.isLoggable(Level.FINEST)) {
-                log.finest("FragmentCompletionTimeDeriver ret=" + ct);
-            }
+            log.debugf("FragmentCompletionTimeDeriver ret= %s", ct);
             return ct;
         }
 
         return null;
     }
 
+    @Override
+    public long getRetryDelay(List<Span> spans, int retryCount) {
+        // TODO HWKAPM-348
+        return 5000;
+    }
 }

--- a/server/processors-zipkin/src/test/java/org/hawkular/apm/server/processor/zipkin/CompletionTimeProcessingDeriverTest.java
+++ b/server/processors-zipkin/src/test/java/org/hawkular/apm/server/processor/zipkin/CompletionTimeProcessingDeriverTest.java
@@ -20,7 +20,9 @@ package org.hawkular.apm.server.processor.zipkin;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.server.api.model.zipkin.Annotation;
+import org.hawkular.apm.server.api.model.zipkin.BinaryAnnotation;
 import org.hawkular.apm.server.api.model.zipkin.Span;
 import org.hawkular.apm.server.api.services.SpanCache;
 import org.hawkular.apm.server.api.task.RetryAttemptException;
@@ -38,16 +40,20 @@ public class CompletionTimeProcessingDeriverTest {
         SpanCache spanCacheMock = Mockito.mock(SpanCache.class);
         CompletionTimeProcessingDeriver completionTimeProcessingDeriver = new CompletionTimeProcessingDeriver(spanCacheMock);
 
-        Span rootSpan = new Span();
+        Annotation sr = new Annotation();
+        sr.setValue("sr");
+        sr.setTimestamp(0);
+        Annotation ss = new Annotation();
+        ss.setTimestamp(1000);
+        ss.setValue("ss");
+        BinaryAnnotation httpAddress = new BinaryAnnotation();
+        httpAddress.setKey(Constants.ZIPKIN_BIN_ANNOTATION_HTTP_URL);
+        httpAddress.setValue("http://localhost");
+        Span rootSpan = new Span(Arrays.asList(httpAddress), Arrays.asList(sr, ss));
         rootSpan.setId("trace");
         rootSpan.setTraceId("trace");
         rootSpan.setTimestamp(0);
-        Annotation annotation = new Annotation();
-        annotation.setTimestamp(0);
-        Annotation annotation1 = new Annotation();
-        annotation1.setTimestamp(1000);
-        rootSpan.setDuration(annotation1.getTimestamp() - annotation.getTimestamp());
-        rootSpan.setAnnotations(Arrays.asList(annotation, annotation1));
+        rootSpan.setDuration(ss.getTimestamp() - sr.getTimestamp());
         Mockito.when(spanCacheMock.getTrace(null, "trace")).thenReturn(new HashSet<>(Arrays.asList(rootSpan)));
 
         CompletionTimeProcessing completionTimeProcessing = new CompletionTimeProcessing(rootSpan);
@@ -61,15 +67,14 @@ public class CompletionTimeProcessingDeriverTest {
         completionTimeProcessing = completionTimeProcessingDeriver.processOneToOne(null, completionTimeProcessing);
         Assert.assertNull(completionTimeProcessing);
 
-        Span descendant = new Span();
+        sr = new Annotation();
+        sr.setTimestamp(1500);
+        ss = new Annotation();
+        ss.setTimestamp(2000);
+        Span descendant = new Span(null, Arrays.asList(sr, ss));
         descendant.setId("descendant");
         descendant.setTraceId("trace");
         descendant.setTimestamp(1500);
-        annotation = new Annotation();
-        annotation.setTimestamp(1500);
-        annotation1 = new Annotation();
-        annotation1.setTimestamp(2000);
-        descendant.setAnnotations(Arrays.asList(annotation, annotation1));
         Mockito.when(spanCacheMock.getTrace(null, "trace")).thenReturn(
                 new HashSet<>(Arrays.asList(rootSpan, descendant)));
 

--- a/tests/server/wildfly/src/test/java/org/hawkular/apm/tests/wildfly/AnalyticsServiceRESTTest.java
+++ b/tests/server/wildfly/src/test/java/org/hawkular/apm/tests/wildfly/AnalyticsServiceRESTTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.hawkular.apm.analytics.service.rest.client.AnalyticsServiceRESTClient;
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.PropertyType;
 import org.hawkular.apm.api.model.analytics.Cardinality;
@@ -659,7 +660,7 @@ public class AnalyticsServiceRESTTest {
         trace1.getNodes().add(c1);
 
         Component comp1 = new Component();
-        comp1.setComponentType("Database");
+        comp1.setComponentType(Constants.COMPONENT_DATABASE);
         comp1.setUri("jdbc:h2:hello");
         comp1.setOperation("query");
         comp1.setDuration(600000);
@@ -708,7 +709,7 @@ public class AnalyticsServiceRESTTest {
         trace1.getNodes().add(c1);
 
         Component comp1 = new Component();
-        comp1.setComponentType("Database");
+        comp1.setComponentType(Constants.COMPONENT_DATABASE);
         comp1.setUri("jdbc:h2:hello");
         comp1.setOperation("query");
         comp1.setDuration(600000);
@@ -765,7 +766,7 @@ public class AnalyticsServiceRESTTest {
         trace1.getNodes().add(c1);
 
         Component comp1 = new Component();
-        comp1.setComponentType("Database");
+        comp1.setComponentType(Constants.COMPONENT_DATABASE);
         comp1.setUri("jdbc:h2:hello");
         comp1.setOperation("query");
         comp1.setDuration(600000);
@@ -813,7 +814,7 @@ public class AnalyticsServiceRESTTest {
         trace1.getNodes().add(c1);
 
         Component comp1 = new Component();
-        comp1.setComponentType("Database");
+        comp1.setComponentType(Constants.COMPONENT_DATABASE);
         comp1.setUri("jdbc:h2:hello");
         comp1.setOperation("query");
         comp1.setDuration(600000);

--- a/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
+++ b/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
@@ -164,8 +164,16 @@ render.shapes().component = function(parent, bbox, node) {
           }
         }
         if (!skip) {
+          // if there is no uri show service name
+          let uri = d.uri;
+          if (uri == null) {
+            let prop: any = _.find(d.properties, {name: 'service'});
+            if (prop) {
+              uri = 'service: ' + prop.value;
+            }
+          }
 
-          let label = '<div class="name" style="color: #eee;">' + d.uri + '</div>';
+          let label = '<div class="name" style="color: #eee;">' + uri + '</div>';
           if (theShape === 'circle') {
             label = '<div><i class="fa fa-share-alt" style="color: #ddd; font-size: 2.5em; margin: 0.2em;"></i></div>';
           } else if (d.componentType === 'Database') {


### PR DESCRIPTION
* deriving service name from  `Endpoint` contained in annotation (not binary as before)
* instance details view  if `url == null` it shows service name
* changed client spans of C* requests to use name query(the same as mysql instrumentation)  and added binary annotation sql.query with a query statement.
* `spanService#getSpan` adds client's binary annotations if URL of server span is null.

Review notes:
please run polyglot-example

Bugs: 
1. roda endpoint it not shown in distributed tracing tab (instance detail view is ok) -> FIXED
2. call `curl -ivX POST -H 'Content-Type: application/json' 'http://localhost:3001/nodejs/createUser' -d '{"name": "jdoe"}'` and ` curl -ivX POST -H 'Content-Type: application/json' 'http://localhost:3000/dropwizard/users' -d '{"name": "jdoe"}'` or curl -ivX POST -H 'Content-Type: application/json' 'http://localhost:3003/wildfly-swarm/users' -d '{"name": "jdoe"}'. Root node does not show option to select root dropwizard or wildfly-swarm as an option. (This might not be related to polyglot example.) @objectiser what do you think (jira https://issues.jboss.org/browse/HWKAPM-630)?

