### PR TITLE
fix url seperator error on window

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/services/ConfigurationLoader.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/ConfigurationLoader.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 
 import org.hawkular.apm.api.logging.Logger;
 import org.hawkular.apm.api.logging.Logger.Level;
@@ -107,7 +108,7 @@ public class ConfigurationLoader {
         }
 
         if (uri != null) {
-            String[] uriParts = uri.split(java.io.File.separator);
+            String[] uriParts = uri.split(Matcher.quoteReplacement(File.separator));
             int startIndex = 0;
 
             // Remove any file prefix


### PR DESCRIPTION
similar error like [link](https://github.com/swagger-api/swagger-codegen/commit/2a5bd0a80ec13644ace353a8c911a2b9ca102b0b)

```
  import java.util.regex.Matcher;
  import java.io.File;
  ...
  String str = "foo" + File.separator + "bar";
  //following will fail
  // str.split(File.separator);
  //following is OK
  str.split(Matcher.quoteReplacement(File.separator));

``` 