### PR TITLE
HWKAPM-641 | updated docker client version, for docker > 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <version.com.github.eirslett.frontend-maven-plugin>1.0</version.com.github.eirslett.frontend-maven-plugin>
 
     <version.com.fasterxml.jackson.core>2.6.0</version.com.fasterxml.jackson.core>
-    <version.com.github.docker-java.docker-java>3.0.0</version.com.github.docker-java.docker-java>
+    <version.com.github.docker-java.docker-java>3.0.6</version.com.github.docker-java.docker-java>
     <version.com.jayway.jsonpath>2.2.0</version.com.jayway.jsonpath>
     <version.commons-io>2.1</version.commons-io>
     <version.io.opentracing>0.15.0</version.io.opentracing>


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-641

tested on:
```
Client:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   23cf638
 Built:        
 OS/Arch:      linux/amd64

Server:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   23cf638
 Built:        
 OS/Arch:      linux/amd64
```


@objectiser could you please review? Could you please run it too?