### PR TITLE
HWKAPM-610 | On Jenkins APM mock server fails to capture objects [Instrumentation Test Framework]

### DIFF
--- a/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/TestScenarioRunner.java
+++ b/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/TestScenarioRunner.java
@@ -125,8 +125,9 @@ public class TestScenarioRunner {
 
         String environmentId = null;
         ApmMockServer apmServer = new ApmMockServer();
-        apmServer.setHost("0.0.0.0");
         apmServer.setPort(apmServerPort);
+        // TODO Jenkins torii
+        apmServer.setHost("0.0.0.0");
         // disable shut down timer
         apmServer.setShutdownTimer(60*60*1000);
         try {


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-610

The problem is with a firewall configuration on slave01, slave02. Use this PR as a build trigger.
