### PR TITLE
remove auto generated comments from eclipse

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/AddContentActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/AddContentActionHandler.java
@@ -41,7 +41,6 @@ public class AddContentActionHandler extends ExpressionBasedActionHandler {
 
     private static final Logger log = Logger.getLogger(AddContentActionHandler.class.getName());
 
-    /**  */
     private static final String NAME_MUST_BE_SPECIFIED = "Name must be specified";
 
     /**
@@ -79,11 +78,6 @@ public class AddContentActionHandler extends ExpressionBasedActionHandler {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.collector.internal.actions.ProcessorActionHandler#process(
-     *      org.hawkular.apm.api.model.trace.Trace, org.hawkular.apm.api.model.trace.Node,
-     *      org.hawkular.apm.api.model.config.Direction, java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean process(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/AddCorrelationIdActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/AddCorrelationIdActionHandler.java
@@ -41,11 +41,6 @@ public class AddCorrelationIdActionHandler extends ExpressionBasedActionHandler 
         super(action);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.collector.internal.actions.ProcessorActionHandler#process(
-     *      org.hawkular.apm.api.model.trace.Trace, org.hawkular.apm.api.model.trace.Node,
-     *      org.hawkular.apm.api.model.config.Direction, java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean process(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/EvaluateURIActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/EvaluateURIActionHandler.java
@@ -48,7 +48,6 @@ public class EvaluateURIActionHandler extends ProcessorActionHandler {
 
     private static final Logger log = Logger.getLogger(EvaluateURIActionHandler.class.getName());
 
-    /**  */
     public static final String TEMPLATE_MUST_BE_SPECIFIED = "Template must be specified";
 
     private String pathTemplate;
@@ -112,11 +111,6 @@ public class EvaluateURIActionHandler extends ProcessorActionHandler {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.collector.internal.actions.ProcessorActionHandler#process(
-     *      org.hawkular.apm.api.model.trace.Trace, org.hawkular.apm.api.model.trace.Node,
-     *      org.hawkular.apm.api.model.config.Direction, java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean process(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/ExpressionBasedActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/ExpressionBasedActionHandler.java
@@ -36,7 +36,6 @@ import org.hawkular.apm.api.model.trace.Trace;
  */
 public abstract class ExpressionBasedActionHandler extends ProcessorActionHandler {
 
-    /**  */
     public static final String EXPRESSION_HAS_NOT_BEEN_DEFINED = "Expression has not been defined";
 
     private static final Logger log = Logger.getLogger(ExpressionBasedActionHandler.class.getName());

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/JSONExpressionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/JSONExpressionHandler.java
@@ -41,22 +41,11 @@ public class JSONExpressionHandler extends DataExpressionHandler {
         super(expression);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#init(
-     *              org.hawkular.apm.api.model.config.btxn.Processor,
-     *              org.hawkular.apm.api.model.config.btxn.ProcessorAction, boolean)
-     */
     @Override
     public void init(Processor processor, ProcessorAction action, boolean predicate) {
         super.init(processor, action, predicate);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#predicate(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean test(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {
@@ -64,12 +53,6 @@ public class JSONExpressionHandler extends DataExpressionHandler {
                             getDataValue(trace, node, direction, headers, values));
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#test(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public String evaluate(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/LiteralExpressionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/LiteralExpressionHandler.java
@@ -46,11 +46,6 @@ public class LiteralExpressionHandler extends ExpressionHandler {
         super(expression);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#init(
-     *              org.hawkular.apm.api.model.config.btxn.Processor,
-     *              org.hawkular.apm.api.model.config.btxn.ProcessorAction, boolean)
-     */
     @Override
     public void init(Processor processor, ProcessorAction action, boolean predicate) {
         LiteralExpression expr = (LiteralExpression) getExpression();
@@ -74,24 +69,12 @@ public class LiteralExpressionHandler extends ExpressionHandler {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#test(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean test(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {
         return predicateResult;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#test(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public String evaluate(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/SetDetailActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/SetDetailActionHandler.java
@@ -36,7 +36,6 @@ import org.hawkular.apm.api.model.trace.Trace;
  */
 public class SetDetailActionHandler extends ExpressionBasedActionHandler {
 
-    /**  */
     private static final String NAME_MUST_BE_SPECIFIED = "Name must be specified";
 
     /**
@@ -74,11 +73,6 @@ public class SetDetailActionHandler extends ExpressionBasedActionHandler {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.collector.internal.actions.ProcessorActionHandler#process(
-     *      org.hawkular.apm.api.model.trace.Trace, org.hawkular.apm.api.model.trace.Node,
-     *      org.hawkular.apm.api.model.config.Direction, java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean process(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandler.java
@@ -39,11 +39,6 @@ public class SetFaultActionHandler extends ExpressionBasedActionHandler {
         super(action);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.collector.internal.actions.ProcessorActionHandler#process(
-     *      org.hawkular.apm.api.model.trace.Trace, org.hawkular.apm.api.model.trace.Node,
-     *      org.hawkular.apm.api.model.config.Direction, java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean process(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/SetPropertyActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/SetPropertyActionHandler.java
@@ -37,7 +37,6 @@ import org.hawkular.apm.api.model.trace.Trace;
  */
 public class SetPropertyActionHandler extends ExpressionBasedActionHandler {
 
-    /**  */
     public static final String NAME_MUST_BE_SPECIFIED = "Name must be specified";
 
     /**
@@ -75,11 +74,6 @@ public class SetPropertyActionHandler extends ExpressionBasedActionHandler {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.collector.internal.actions.ProcessorActionHandler#process(
-     *      org.hawkular.apm.api.model.trace.Trace, org.hawkular.apm.api.model.trace.Node,
-     *      org.hawkular.apm.api.model.config.Direction, java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean process(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/TextExpressionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/TextExpressionHandler.java
@@ -40,22 +40,11 @@ public class TextExpressionHandler extends DataExpressionHandler {
         super(expression);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#init(
-     *              org.hawkular.apm.api.model.config.btxn.Processor,
-     *              org.hawkular.apm.api.model.config.btxn.ProcessorAction, boolean)
-     */
     @Override
     public void init(Processor processor, ProcessorAction action, boolean predicate) {
         super.init(processor, action, predicate);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#predicate(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean test(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {
@@ -64,12 +53,6 @@ public class TextExpressionHandler extends DataExpressionHandler {
         return result != null && result.equalsIgnoreCase("true");
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#test(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public String evaluate(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/XMLExpressionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/XMLExpressionHandler.java
@@ -41,11 +41,6 @@ public class XMLExpressionHandler extends DataExpressionHandler {
         super(expression);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#init(
-     *              org.hawkular.apm.api.model.config.btxn.Processor,
-     *              org.hawkular.apm.api.model.config.btxn.ProcessorAction, boolean)
-     */
     @Override
     public void init(Processor processor, ProcessorAction action, boolean predicate) {
         super.init(processor, action, predicate);
@@ -53,12 +48,6 @@ public class XMLExpressionHandler extends DataExpressionHandler {
         // TODO: Expression validation
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#predicate(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public boolean test(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {
@@ -66,12 +55,6 @@ public class XMLExpressionHandler extends DataExpressionHandler {
                 getDataValue(trace, node, direction, headers, values));
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.internal.actions.ExpressionHandler#test(
-     *              org.hawkular.apm.api.model.trace.Trace,
-     *              org.hawkular.apm.api.model.trace.Node, org.hawkular.apm.api.model.config.Direction,
-     *              java.util.Map, java.lang.Object[])
-     */
     @Override
     public String evaluate(Trace trace, Node node, Direction direction, Map<String, ?> headers,
             Object[] values) {

--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/helpers/XML.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/helpers/XML.java
@@ -43,9 +43,7 @@ public class XML {
 
     private static final Logger log = Logger.getLogger(XML.class.getName());
 
-    /**  */
     private static final String DEFAULT_INDENT = "yes";
-    /**  */
     private static final String DEFAULT_ENCODING = "UTF-8";
 
     /**

--- a/api/src/main/java/org/hawkular/apm/api/model/Property.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/Property.java
@@ -138,17 +138,11 @@ public class Property implements Externalizable {
         this.number = number;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Property [name=" + name + ", value=" + value + ", type=" + type + ", number=" + number + "]";
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -159,9 +153,6 @@ public class Property implements Externalizable {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -186,9 +177,6 @@ public class Property implements Externalizable {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.io.Externalizable#readExternal(java.io.ObjectInput)
-     */
     @Override
     public void readExternal(ObjectInput ois) throws IOException, ClassNotFoundException {
         ois.readInt(); // Read version
@@ -199,9 +187,6 @@ public class Property implements Externalizable {
         number = ois.readDouble();
     }
 
-    /* (non-Javadoc)
-     * @see java.io.Externalizable#writeExternal(java.io.ObjectOutput)
-     */
     @Override
     public void writeExternal(ObjectOutput oos) throws IOException {
         oos.writeInt(1); // Write version

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/Cardinality.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/Cardinality.java
@@ -59,9 +59,6 @@ public class Cardinality {
         this.count = count;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Cardinality [value=" + value + ", count=" + count + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/CompletionTimeseriesStatistics.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/CompletionTimeseriesStatistics.java
@@ -127,9 +127,6 @@ public class CompletionTimeseriesStatistics {
         this.max = max;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "CompletionTimeseriesStatistics [timestamp=" + timestamp + ", count=" + count + ", faultCount="

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/EndpointInfo.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/EndpointInfo.java
@@ -175,9 +175,6 @@ public class EndpointInfo {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "EndpointInfo [endpoint=" + endpoint + ", type=" + type + ", regex=" + regex + ", uriRegex=" + uriRegex

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/NodeSummaryStatistics.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/NodeSummaryStatistics.java
@@ -128,9 +128,6 @@ public class NodeSummaryStatistics {
         this.operation = operation;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "NodeSummaryStatistics [actual=" + actual + ", elapsed=" + elapsed + ", count=" + count

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/NodeTimeseriesStatistics.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/NodeTimeseriesStatistics.java
@@ -63,9 +63,6 @@ public class NodeTimeseriesStatistics {
         this.componentTypes = componentTypes;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "NodeTimeseriesStatistics [timestamp=" + timestamp + ", componentTypes=" + componentTypes + "]";
@@ -127,9 +124,6 @@ public class NodeTimeseriesStatistics {
             this.count = count;
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#toString()
-         */
         @Override
         public String toString() {
             return "NodeComponentTypeStatistics [duration=" + duration + ", count=" + count + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/PrincipalInfo.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/PrincipalInfo.java
@@ -60,9 +60,6 @@ public class PrincipalInfo {
         this.count = count;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "PrincipalInfo [id=" + id + ", count=" + count + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/PropertyInfo.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/PropertyInfo.java
@@ -43,9 +43,6 @@ public class PropertyInfo {
         this.name = name;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "PropertyInfo [name=" + name + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/analytics/TransactionInfo.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/analytics/TransactionInfo.java
@@ -104,18 +104,12 @@ public class TransactionInfo {
         return this;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "TransactionInfo [name=" + name + ", count=" + count + ", level=" + level + ", staticConfig="
                 + staticConfig + "]";
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -127,9 +121,6 @@ public class TransactionInfo {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/AddContentAction.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/AddContentAction.java
@@ -60,9 +60,6 @@ public class AddContentAction extends ExpressionBasedAction {
         this.type = type;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "AddContentAction [name=" + name + ", type=" + type + ", getExpression()=" + getExpression()

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/AddCorrelationIdAction.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/AddCorrelationIdAction.java
@@ -45,9 +45,6 @@ public class AddCorrelationIdAction extends ExpressionBasedAction {
         this.scope = scope;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "AddCorrelationIdAction [scope=" + scope + ", getExpression()=" + getExpression()

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/BusinessTxnConfig.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/BusinessTxnConfig.java
@@ -133,9 +133,6 @@ public class BusinessTxnConfig {
         this.deleted = deleted;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "BusinessTxnConfig [level=" + level + ", description=" + description + ", filter=" + filter

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/BusinessTxnSummary.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/BusinessTxnSummary.java
@@ -79,9 +79,6 @@ public class BusinessTxnSummary {
         this.description = description;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "BusinessTxnSummary [name=" + name + ", level=" + level + ", description=" + description + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/ConfigMessage.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/ConfigMessage.java
@@ -114,9 +114,6 @@ public class ConfigMessage {
         this.field = field;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "ConfigMessage [severity=" + severity + ", message=" + message + ", processor=" + processor

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/Filter.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/Filter.java
@@ -62,9 +62,6 @@ public class Filter {
         this.exclusions = exclusions;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Filter [inclusions=" + inclusions + ", exclusions=" + exclusions + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/JSONExpression.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/JSONExpression.java
@@ -42,9 +42,6 @@ public class JSONExpression extends DataExpression {
         this.jsonpath = jsonpath;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "JSONExpression [jsonpath=" + jsonpath + ", getSource()=" + getSource() + ", getKey()=" + getKey()

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/LiteralExpression.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/LiteralExpression.java
@@ -44,9 +44,6 @@ public class LiteralExpression extends Expression {
         return this;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Literal [value=" + value + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/Processor.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/Processor.java
@@ -170,9 +170,6 @@ public class Processor {
         this.actions = actions;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Processor [description=" + description + ", nodeType=" + nodeType + ", direction=" + direction

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/SetDetailAction.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/SetDetailAction.java
@@ -43,9 +43,6 @@ public class SetDetailAction extends ExpressionBasedAction {
         this.name = name;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "SetDetailAction [name=" + name + ", getExpression()=" + getExpression() + ", getDescription()="

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/SetFaultAction.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/SetFaultAction.java
@@ -24,9 +24,6 @@ package org.hawkular.apm.api.model.config.btxn;
  */
 public class SetFaultAction extends ExpressionBasedAction {
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "SetFaultAction [getExpression()=" + getExpression() + ", getDescription()=" + getDescription()

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/SetPropertyAction.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/SetPropertyAction.java
@@ -62,9 +62,6 @@ public class SetPropertyAction extends ExpressionBasedAction {
         this.type = type;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "SetPropertyAction [name=" + name + ", type=" + type + ", getExpression()=" + getExpression()

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/TextExpression.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/TextExpression.java
@@ -23,9 +23,6 @@ package org.hawkular.apm.api.model.config.btxn;
  */
 public class TextExpression extends DataExpression {
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Text [getSource()=" + getSource() + ", getKey()=" + getKey()

--- a/api/src/main/java/org/hawkular/apm/api/model/config/btxn/XMLExpression.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/config/btxn/XMLExpression.java
@@ -42,9 +42,6 @@ public class XMLExpression extends DataExpression {
         this.xpath = xpath;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "XMLExpression [xpath=" + xpath + ", getSource()=" + getSource() + ", getKey()=" + getKey()

--- a/api/src/main/java/org/hawkular/apm/api/model/events/CommunicationDetails.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/events/CommunicationDetails.java
@@ -438,9 +438,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
         this.outbound = outbound;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "CommunicationDetails [id=" + id + ", linkId=" + linkId + ", businessTransaction=" + businessTransaction
@@ -454,9 +451,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
                 + properties + ", outbound=" + outbound + "]";
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -486,9 +480,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -587,9 +578,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.io.Externalizable#readExternal(java.io.ObjectInput)
-     */
     @Override
     public void readExternal(ObjectInput ois) throws IOException, ClassNotFoundException {
         ois.readInt(); // Version
@@ -626,9 +614,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
         }
     }
 
-    /* (non-Javadoc)
-     * @see java.io.Externalizable#writeExternal(java.io.ObjectOutput)
-     */
     @Override
     public void writeExternal(ObjectOutput oos) throws IOException {
         oos.writeInt(1); // Version
@@ -720,9 +705,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
             this.producerOffset = producerOffset;
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#hashCode()
-         */
         @Override
         public int hashCode() {
             final int prime = 31;
@@ -733,9 +715,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
             return result;
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#equals(java.lang.Object)
-         */
         @Override
         public boolean equals(Object obj) {
             if (this == obj) {
@@ -764,18 +743,12 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
             return true;
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#toString()
-         */
         @Override
         public String toString() {
             return "Outbound [linkIds=" + linkIds + ", multiConsumer=" + multiConsumer + ", producerOffset=" + producerOffset
                     + "]";
         }
 
-        /* (non-Javadoc)
-         * @see java.io.Externalizable#readExternal(java.io.ObjectInput)
-         */
         @Override
         public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
             in.readInt(); // Version
@@ -789,9 +762,6 @@ public class CommunicationDetails implements Externalizable, ApmEvent {
             producerOffset = in.readLong();
         }
 
-        /* (non-Javadoc)
-         * @see java.io.Externalizable#writeExternal(java.io.ObjectOutput)
-         */
         @Override
         public void writeExternal(ObjectOutput out) throws IOException {
             out.writeInt(1); // Version

--- a/api/src/main/java/org/hawkular/apm/api/model/events/CompletionTime.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/events/CompletionTime.java
@@ -295,9 +295,6 @@ public class CompletionTime implements ApmEvent {
         this.internal = internal;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "CompletionTime [id=" + id + ", uri=" + uri + ", operation=" + operation + ", endpointType="

--- a/api/src/main/java/org/hawkular/apm/api/model/events/NodeDetails.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/events/NodeDetails.java
@@ -352,9 +352,6 @@ public class NodeDetails implements ApmEvent {
         this.correlationIds = correlationIds;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -377,9 +374,6 @@ public class NodeDetails implements ApmEvent {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -455,9 +449,6 @@ public class NodeDetails implements ApmEvent {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "NodeDetails [id=" + id + ", businessTransaction=" + businessTransaction + ", type=" + type + ", uri="

--- a/api/src/main/java/org/hawkular/apm/api/model/events/Notification.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/events/Notification.java
@@ -151,9 +151,6 @@ public class Notification implements ApmEvent {
         this.issues = issues;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Notification [id=" + id + ", businessTransaction=" + businessTransaction + ", timestamp=" + timestamp

--- a/api/src/main/java/org/hawkular/apm/api/model/events/SourceInfo.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/events/SourceInfo.java
@@ -325,9 +325,6 @@ public class SourceInfo implements Externalizable, ApmEvent {
         }
     }
 
-    /* (non-Javadoc)
-     * @see java.io.Externalizable#writeExternal(java.io.ObjectOutput)
-     */
     @Override
     public void writeExternal(ObjectOutput oos) throws IOException {
         oos.writeInt(1); // Write version

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Component.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Component.java
@@ -55,9 +55,6 @@ public class Component extends InteractionNode {
         this.componentType = componentType;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -66,9 +63,6 @@ public class Component extends InteractionNode {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -94,9 +88,6 @@ public class Component extends InteractionNode {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Component [componentType=" + componentType + ", getIn()=" + getIn() + ", getOut()=" + getOut()

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Consumer.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Consumer.java
@@ -56,9 +56,6 @@ public class Consumer extends InteractionNode {
         this.endpointType = endpointType;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -67,9 +64,6 @@ public class Consumer extends InteractionNode {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -95,9 +89,6 @@ public class Consumer extends InteractionNode {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Consumer [endpointType=" + endpointType + ", getIn()=" + getIn() + ", getOut()=" + getOut()

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Content.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Content.java
@@ -68,9 +68,6 @@ public class Content {
         this.value = value;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -80,9 +77,6 @@ public class Content {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -105,9 +99,6 @@ public class Content {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Content [type=" + type + ", value=" + value + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/CorrelationIdentifier.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/CorrelationIdentifier.java
@@ -117,9 +117,6 @@ public class CorrelationIdentifier {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "CorrelationIdentifier [value=" + value + ", scope=" + scope + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/InteractionNode.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/InteractionNode.java
@@ -99,9 +99,6 @@ public abstract class InteractionNode extends ContainerNode {
                 .equalsIgnoreCase(Boolean.TRUE.toString());
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -111,9 +108,6 @@ public abstract class InteractionNode extends ContainerNode {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Issue.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Issue.java
@@ -78,9 +78,6 @@ public abstract class Issue {
         this.severity = severity;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Issue [description=" + description + ", severity=" + severity + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Message.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Message.java
@@ -81,9 +81,6 @@ public class Message {
         return this;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -93,9 +90,6 @@ public class Message {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -125,9 +119,6 @@ public class Message {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Message [headers=" + headers + ", content=" + content + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Node.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Node.java
@@ -437,9 +437,6 @@ public abstract class Node {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -457,9 +454,6 @@ public abstract class Node {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/ProcessorIssue.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/ProcessorIssue.java
@@ -83,9 +83,6 @@ public class ProcessorIssue extends Issue {
         this.field = field;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "ProcessorIssue [processor=" + processor + ", action=" + action + ", field=" + field + "]";

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Producer.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Producer.java
@@ -56,9 +56,6 @@ public class Producer extends InteractionNode {
         this.endpointType = endpointType;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -67,9 +64,6 @@ public class Producer extends InteractionNode {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -95,9 +89,6 @@ public class Producer extends InteractionNode {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Producer [endpointType=" + endpointType + ", getIn()=" + getIn() + ", getOut()=" + getOut()

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Trace.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Trace.java
@@ -292,9 +292,6 @@ public class Trace {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -309,9 +306,6 @@ public class Trace {
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -372,9 +366,6 @@ public class Trace {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Trace [id=" + id + ", startTime=" + startTime

--- a/api/src/main/java/org/hawkular/apm/api/services/AbstractAnalyticsService.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/AbstractAnalyticsService.java
@@ -86,10 +86,6 @@ public abstract class AbstractAnalyticsService implements AnalyticsService {
      */
     protected abstract List<Trace> getFragments(String tenantId, Criteria criteria);
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getUnboundEndpoints(java.lang.String,
-     *                                  long, long, boolean)
-     */
     @Override
     public List<EndpointInfo> getUnboundEndpoints(String tenantId, long startTime, long endTime, boolean compress) {
         Criteria criteria = new Criteria();
@@ -100,10 +96,6 @@ public abstract class AbstractAnalyticsService implements AnalyticsService {
         return (doGetUnboundEndpoints(tenantId, fragments, compress));
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getBoundEndpoints(java.lang.String,
-     *                               java.lang.String, long, long)
-     */
     @Override
     public List<EndpointInfo> getBoundEndpoints(String tenantId, String businessTransaction, long startTime,
                                     long endTime) {
@@ -286,10 +278,6 @@ public abstract class AbstractAnalyticsService implements AnalyticsService {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCommunicationSummaryStatistics(java.lang.String,
-     *                          org.hawkular.apm.api.services.Criteria, boolean)
-     */
     @Override
     public Collection<CommunicationSummaryStatistics> getCommunicationSummaryStatistics(String tenantId,
             Criteria criteria, boolean asTree) {
@@ -542,7 +530,6 @@ public abstract class AbstractAnalyticsService implements AnalyticsService {
      */
     public static class EndpointPart {
 
-        /**  */
         private static final int CHILD_THRESHOLD = 10;
         private int count = 1;
         private Map<String, EndpointPart> children;

--- a/api/src/main/java/org/hawkular/apm/api/services/AbstractConfigurationService.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/AbstractConfigurationService.java
@@ -36,13 +36,8 @@ import org.hawkular.apm.api.model.trace.ProcessorIssue;
  */
 public abstract class AbstractConfigurationService implements ConfigurationService {
 
-    /**  */
     private static final String NO_FILTERS = "No inclusion or exclusion filters have been defined";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#validateBusinessTransaction(
-     *                  org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig)
-     */
     @Override
     public List<ConfigMessage> validateBusinessTransaction(BusinessTxnConfig config) {
         List<ConfigMessage> messages = new ArrayList<ConfigMessage>();
@@ -85,9 +80,6 @@ public abstract class AbstractConfigurationService implements ConfigurationServi
         return messages;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransactions(java.lang.String, java.util.Map)
-     */
     @Override
     public List<ConfigMessage> setBusinessTransactions(String tenantId, Map<String, BusinessTxnConfig> configs)
             throws Exception {

--- a/api/src/main/java/org/hawkular/apm/api/services/ConfigurationLoader.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/ConfigurationLoader.java
@@ -46,13 +46,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class ConfigurationLoader {
 
-    /**  */
     private static final String DEFAULT_TYPE = "jvm";
 
     /** The system property that optional contains the location of the configuration */
     public static final String HAWKULAR_APM_CONFIG = "HAWKULAR_APM_CONFIG";
 
-    /**  */
     private static final String DEFAULT_URI = "apmconfig";
 
     private static ObjectMapper mapper = new ObjectMapper();

--- a/api/src/main/java/org/hawkular/apm/api/services/Criteria.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/Criteria.java
@@ -47,10 +47,8 @@ public class Criteria {
     private String uri;
     private String operation;
 
-    /**  */
     private static int DEFAULT_RESPONSE_SIZE = 100000;
 
-    /**  */
     private static long DEFAULT_TIMEOUT = 10000L;
 
     private long timeout = DEFAULT_TIMEOUT;
@@ -474,9 +472,6 @@ public class Criteria {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Criteria [startTime=" + startTime + ", endTime=" + endTime + ", businessTransaction="
@@ -621,9 +616,6 @@ public class Criteria {
             return buf.toString();
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#toString()
-         */
         @Override
         public String toString() {
             return "PropertyCriteria [name=" + name + ", value=" + value + ", operator=" + operator + "]";
@@ -714,9 +706,6 @@ public class Criteria {
             return buf.toString();
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#toString()
-         */
         @Override
         public String toString() {
             return "FaultCriteria [value=" + value + ", operator=" + operator + "]";

--- a/api/src/main/java/org/hawkular/apm/api/services/StoreException.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/StoreException.java
@@ -23,7 +23,6 @@ package org.hawkular.apm.api.services;
  */
 public class StoreException extends Exception {
 
-    /**  */
     private static final long serialVersionUID = -2673182772454488068L;
 
     /**

--- a/api/src/main/java/org/hawkular/apm/api/services/internal/CommunicationSeverityAnalyser.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/internal/CommunicationSeverityAnalyser.java
@@ -35,7 +35,6 @@ public class CommunicationSeverityAnalyser {
     // NOTE: May want to provide a pluggable algorithm, but for now just implement
     // a basic approach
 
-    /**  */
     private static final int MAX_SEVERITY = 5;
 
     /**

--- a/api/src/main/java/org/hawkular/apm/api/utils/NodeUtil.java
+++ b/api/src/main/java/org/hawkular/apm/api/utils/NodeUtil.java
@@ -29,7 +29,6 @@ import org.hawkular.apm.api.model.trace.Node;
  */
 public class NodeUtil {
 
-    /**  */
     private static final String APM_ORIGINAL_URI = "apm_original_uri";
 
     /**

--- a/api/src/main/java/org/hawkular/apm/api/utils/PropertyUtil.java
+++ b/api/src/main/java/org/hawkular/apm/api/utils/PropertyUtil.java
@@ -31,7 +31,6 @@ public class PropertyUtil {
 
     private static final Logger LOG = Logger.getLogger(PropertyUtil.class.getName());
 
-    /**  */
     public static final String HAWKULAR_TENANT = "HAWKULAR_TENANT";
 
     /**

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/AddContentActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/AddContentActionHandlerTest.java
@@ -33,13 +33,10 @@ import org.junit.Test;
  */
 public class AddContentActionHandlerTest {
 
-    /**  */
     private static final String TEST_TYPE_1 = "testtype1";
 
-    /**  */
     private static final String TEST_NAME_1 = "testname1";
 
-    /**  */
     private static final String TEST_VALUE_1 = "testvalue1";
 
     @Test

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/AddCorrelationIdActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/AddCorrelationIdActionHandlerTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
  */
 public class AddCorrelationIdActionHandlerTest {
 
-    /**  */
     private static final String TEST_VALUE_1 = "testvalue1";
 
     @Test

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/SetDetailActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/SetDetailActionHandlerTest.java
@@ -33,10 +33,8 @@ import org.junit.Test;
  */
 public class SetDetailActionHandlerTest {
 
-    /**  */
     private static final String TEST_NAME_1 = "testname1";
 
-    /**  */
     private static final String TEST_VALUE_1 = "testvalue1";
 
     @Test

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandlerTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
  */
 public class SetFaultActionHandlerTest {
 
-    /**  */
     private static final String TEST_VALUE_1 = "testvalue1";
 
     @Test

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/SetPropertyActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/SetPropertyActionHandlerTest.java
@@ -34,10 +34,8 @@ import org.junit.Test;
  */
 public class SetPropertyActionHandlerTest {
 
-    /**  */
     private static final String TEST_NAME_1 = "testname1";
 
-    /**  */
     private static final String TEST_VALUE_1 = "testvalue1";
 
     @Test

--- a/api/src/test/java/org/hawkular/apm/api/services/AbstractConfigurationServiceTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/services/AbstractConfigurationServiceTest.java
@@ -97,20 +97,12 @@ public class AbstractConfigurationServiceTest {
 
     public class TestConfigurationService extends AbstractConfigurationService {
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#getCollector(java.lang.String,
-         *                      java.lang.String, java.lang.String, java.lang.String)
-         */
         @Override
         public CollectorConfiguration getCollector(String tenantId, String type, String host, String server) {
             // TODO Auto-generated method stub
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransaction(java.lang.String,
-         *                  java.lang.String, org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig)
-         */
         @Override
         public List<ConfigMessage> setBusinessTransaction(String tenantId, String name, BusinessTxnConfig config)
                 throws Exception {
@@ -118,9 +110,6 @@ public class AbstractConfigurationServiceTest {
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransactions(java.lang.String, java.util.Map)
-         */
         @Override
         public List<ConfigMessage> setBusinessTransactions(String tenantId, Map<String, BusinessTxnConfig> configs)
                 throws Exception {
@@ -128,47 +117,30 @@ public class AbstractConfigurationServiceTest {
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransaction(java.lang.String,
-         *                  java.lang.String)
-         */
         @Override
         public BusinessTxnConfig getBusinessTransaction(String tenantId, String name) {
             // TODO Auto-generated method stub
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactions(java.lang.String, long)
-         */
         @Override
         public Map<String, BusinessTxnConfig> getBusinessTransactions(String tenantId, long updated) {
             // TODO Auto-generated method stub
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactionSummaries(java.lang.String)
-         */
         @Override
         public List<BusinessTxnSummary> getBusinessTransactionSummaries(String tenantId) {
             // TODO Auto-generated method stub
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#removeBusinessTransaction(java.lang.String,
-         *                  java.lang.String)
-         */
         @Override
         public void removeBusinessTransaction(String tenantId, String name) throws Exception {
             // TODO Auto-generated method stub
 
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#clear(java.lang.String)
-         */
         @Override
         public void clear(String tenantId) {
             // TODO Auto-generated method stub

--- a/api/src/test/java/org/hawkular/apm/api/services/TestService1Impl.java
+++ b/api/src/test/java/org/hawkular/apm/api/services/TestService1Impl.java
@@ -23,17 +23,11 @@ public class TestService1Impl implements TestService, ServiceLifecycle {
 
     private boolean initialised = false;
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ServiceLifecycle#init()
-     */
     @Override
     public void init() {
         initialised = true;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TestService#isInitialised()
-     */
     @Override
     public boolean isInitialised() {
         return initialised;

--- a/api/src/test/java/org/hawkular/apm/api/services/TestService2Impl.java
+++ b/api/src/test/java/org/hawkular/apm/api/services/TestService2Impl.java
@@ -21,17 +21,11 @@ package org.hawkular.apm.api.services;
  */
 public class TestService2Impl implements TestService, ServiceStatus {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ServiceStatus#isAvailable()
-     */
     @Override
     public boolean isAvailable() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TestService#isInitialised()
-     */
     @Override
     public boolean isInitialised() {
         return false;

--- a/api/src/test/java/org/hawkular/apm/api/services/TestService3Impl.java
+++ b/api/src/test/java/org/hawkular/apm/api/services/TestService3Impl.java
@@ -21,17 +21,11 @@ package org.hawkular.apm.api.services;
  */
 public class TestService3Impl implements TestService, ServiceStatus {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ServiceStatus#isAvailable()
-     */
     @Override
     public boolean isAvailable() {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TestService#isInitialised()
-     */
     @Override
     public boolean isInitialised() {
         return false;

--- a/api/src/test/java/org/hawkular/apm/api/utils/EndpointUtilTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/utils/EndpointUtilTest.java
@@ -33,9 +33,7 @@ import org.junit.Test;
  */
 public class EndpointUtilTest {
 
-    /**  */
     private static final String OPERATION = "Op";
-    /**  */
     private static final String URI = "/uri";
 
     @Test

--- a/api/src/test/java/org/hawkular/apm/api/utils/NodeUtilTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/utils/NodeUtilTest.java
@@ -27,9 +27,7 @@ import org.junit.Test;
  */
 public class NodeUtilTest {
 
-    /**  */
     private static final String NEW_URI = "/new/uri";
-    /**  */
     private static final String ORIGINAL_URI = "/original/uri";
 
     @Test

--- a/client/analytics-service-rest-client/src/main/java/org/hawkular/apm/analytics/service/rest/client/AnalyticsServiceRESTClient.java
+++ b/client/analytics-service-rest-client/src/main/java/org/hawkular/apm/analytics/service/rest/client/AnalyticsServiceRESTClient.java
@@ -108,9 +108,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         super(PropertyUtil.HAWKULAR_APM_URI_SERVICES);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getUnboundEndpoints(java.lang.String, long, long, boolean)
-     */
     @Override
     public List<EndpointInfo> getUnboundEndpoints(String tenantId, long startTime, long endTime, boolean compress) {
         if (log.isLoggable(Level.FINEST)) {
@@ -122,10 +119,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, URIINFO_LIST, path, startTime, endTime, compress);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getBoundEndpoints(java.lang.String, java.lang.String,
-     *                                  long, long)
-     */
     @Override
     public List<EndpointInfo> getBoundEndpoints(String tenantId, String businessTransaction, long startTime,
                                                 long endTime) {
@@ -168,10 +161,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, PRINCIPAL_INFO_LIST, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCompletionCount(java.lang.String,
-     *                          org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public long getTraceCompletionCount(String tenantId, Criteria criteria) {
         if (log.isLoggable(Level.FINEST)) {
@@ -183,10 +172,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, LONG, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCompletionFaultCount(java.lang.String,
-     *                      org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public long getTraceCompletionFaultCount(String tenantId, Criteria criteria) {
         if (log.isLoggable(Level.FINEST)) {
@@ -197,9 +182,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, LONG, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getTraceCompletionTimes(java.lang.String, org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public List<CompletionTime> getTraceCompletionTimes(String tenantId, Criteria criteria) {
         if (log.isLoggable(Level.FINEST)) {
@@ -211,10 +193,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, COMPLETION_TIME_LIST, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCompletionPercentiles(java.lang.String,
-     *                      org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public Percentiles getTraceCompletionPercentiles(String tenantId, Criteria criteria) {
         if (log.isLoggable(Level.FINEST)) {
@@ -226,10 +204,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, PERCENTILES_TYPE_REFERENCE, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCompletionStatistics(java.lang.String,
-     *                  org.hawkular.apm.api.services.Criteria, long)
-     */
     @Override
     public List<CompletionTimeseriesStatistics> getTraceCompletionTimeseriesStatistics(String tenantId,
                                                                                        Criteria criteria,
@@ -243,10 +217,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, COMPLETION_STATISTICS_LIST, path, criteria, interval);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCompletionFaultDetails(java.lang.String,
-     *                      org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public List<Cardinality> getTraceCompletionFaultDetails(String tenantId, Criteria criteria) {
         if (log.isLoggable(Level.FINEST)) {
@@ -258,10 +228,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, CARDINALITY_LIST, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCompletionPropertyDetails(java.lang.String,
-     *              org.hawkular.apm.api.services.Criteria, java.lang.String)
-     */
     @Override
     public List<Cardinality> getTraceCompletionPropertyDetails(String tenantId, Criteria criteria,
                                                                String property) {
@@ -276,10 +242,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, CARDINALITY_LIST, path, criteria, property);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getNodeStatistics(java.lang.String,
-     *                      org.hawkular.apm.api.services.Criteria, long)
-     */
     @Override
     public List<NodeTimeseriesStatistics> getNodeTimeseriesStatistics(String tenantId,
                                                                       Criteria criteria, long interval) {
@@ -297,10 +259,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getNodeSummaryStatistics(java.lang.String,
-     *                          org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public Collection<NodeSummaryStatistics> getNodeSummaryStatistics(String tenantId, Criteria criteria) {
         if (log.isLoggable(Level.FINEST)) {
@@ -312,10 +270,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, NODE_SUMMARY_STATISTICS_LIST, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getCommunicationSummaryStatistics(java.lang.String,
-     *                          org.hawkular.apm.api.services.Criteria, boolean)
-     */
     @Override
     public Collection<CommunicationSummaryStatistics> getCommunicationSummaryStatistics(String tenantId,
                                                                                         Criteria criteria, boolean tree) {
@@ -333,44 +287,27 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeCommunicationDetails(java.lang.String, java.util.List)
-     */
     @Override
     public void storeCommunicationDetails(String tenantId, List<CommunicationDetails> communicationDetails)
             throws StoreException {
         throw new UnsupportedOperationException();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeNodeDetails(java.lang.String, java.util.List)
-     */
     @Override
     public void storeNodeDetails(String tenantId, List<NodeDetails> nodeDetails) throws StoreException {
         throw new UnsupportedOperationException();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeCompletionTimes(java.lang.String, java.util.List)
-     */
     @Override
     public void storeTraceCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws StoreException {
         throw new UnsupportedOperationException();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#storeFragmentCompletionTimes(java.lang.String,
-     *                      java.util.List)
-     */
     @Override
     public void storeFragmentCompletionTimes(String tenantId, List<CompletionTime> completionTimes) throws StoreException {
         throw new UnsupportedOperationException();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#getHostNames(java.lang.String,
-     *                      org.hawkular.apm.api.services.BaseCriteria)
-     */
     @Override
     public Set<String> getHostNames(String tenantId, Criteria criteria) {
         if (log.isLoggable(Level.FINEST)) {
@@ -382,9 +319,6 @@ public class AnalyticsServiceRESTClient extends AbstractRESTClient implements An
         return getResultsForUrl(tenantId, STRING_SET, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#clear(java.lang.String)
-     */
     @Override
     public void clear(String tenantId) {
         clear(tenantId, "analytics");

--- a/client/api/src/main/java/org/hawkular/apm/client/api/reporter/BatchTraceReporter.java
+++ b/client/api/src/main/java/org/hawkular/apm/client/api/reporter/BatchTraceReporter.java
@@ -39,18 +39,14 @@ import org.hawkular.apm.api.utils.PropertyUtil;
  */
 public class BatchTraceReporter implements TraceReporter {
 
-    /**  */
     private static final int DEFAULT_BATCH_THREAD_POOL_SIZE = 5;
 
-    /**  */
     private static final String HAWKULAR_APM_TENANT_ID = "HAWKULAR_APM_TENANTID";
 
     private static final Logger log = Logger.getLogger(BatchTraceReporter.class.getName());
 
-    /**  */
     private static final int DEFAULT_BATCH_TIME = 500;
 
-    /**  */
     private static final int DEFAULT_BATCH_SIZE = 1000;
 
     private TracePublisher tracePublisher;
@@ -167,9 +163,6 @@ public class BatchTraceReporter implements TraceReporter {
         this.tenantId = tenantId;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceReporter#report(org.hawkular.apm.api.model.trace.Trace)
-     */
     @Override
     public void report(Trace trace) {
         if (tracePublisher != null) {

--- a/client/api/src/main/java/org/hawkular/apm/client/api/rest/AbstractRESTClient.java
+++ b/client/api/src/main/java/org/hawkular/apm/client/api/rest/AbstractRESTClient.java
@@ -67,9 +67,6 @@ public class AbstractRESTClient implements ServiceStatus {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ServiceStatus#isAvailable()
-     */
     @Override
     public boolean isAvailable() {
         // Check URI is specified and starts with http, so either http: or https:

--- a/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollector.java
+++ b/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollector.java
@@ -227,9 +227,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         reporter.setTenantId(tenantId);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#setName(java.lang.String, java.lang.String)
-     */
     @Override
     public void setBusinessTransaction(String location, String name) {
         if (name == null || name.trim().isEmpty()) {
@@ -261,9 +258,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.TraceCollector#getBusinessTransaction()
-     */
     @Override
     public String getBusinessTransaction() {
         String ret = null;
@@ -293,9 +287,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#setPrincipal(java.lang.String, java.lang.String)
-     */
     @Override
     public void setPrincipal(String location, String principal) {
         if (principal == null || principal.trim().isEmpty()) {
@@ -324,9 +315,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#getPrincipal()
-     */
     @Override
     public String getPrincipal() {
         String ret = null;
@@ -356,9 +344,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#setLevel(java.lang.String, java.lang.String)
-     */
     @Override
     public void setLevel(String location, String level) {
         if (level == null || level.trim().isEmpty()) {
@@ -389,9 +374,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#getLevel()
-     */
     @Override
     public String getLevel() {
         String ret = null;
@@ -421,10 +403,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#consumerStart(java.lang.String,
-     *                      java.lang.String, java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void consumerStart(String location, String uri, String type, String operation, String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -454,10 +432,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#consumerEnd(java.lang.String,
-     *                          java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void consumerEnd(String location, String uri, String type, String operation) {
         if (log.isLoggable(Level.FINEST)) {
@@ -483,10 +457,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#componentStart(java.lang.String,
-     *                      java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void componentStart(String location, String uri, String type, String operation) {
         if (log.isLoggable(Level.FINEST)) {
@@ -512,10 +482,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#componentEnd(java.lang.String,
-     *                      java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void componentEnd(String location, String uri, String type, String operation) {
         if (log.isLoggable(Level.FINEST)) {
@@ -541,10 +507,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#producerStart(java.lang.String,
-     *                      java.lang.String, java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void producerStart(String location, String uri, String type, String operation, String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -574,10 +536,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#producerEnd(java.lang.String,
-     *                          java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void producerEnd(String location, String uri, String type, String operation) {
         if (log.isLoggable(Level.FINEST)) {
@@ -637,9 +595,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         outer.getNodes().remove(inner);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#isInProcessed(java.lang.String)
-     */
     @Override
     public boolean isInProcessed(String location) {
 
@@ -669,9 +624,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#isInContentProcessed(java.lang.String)
-     */
     @Override
     public boolean isInContentProcessed(String location) {
 
@@ -700,9 +652,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#isOutProcessed(java.lang.String)
-     */
     @Override
     public boolean isOutProcessed(String location) {
 
@@ -732,9 +681,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#isOutContentProcessed(java.lang.String)
-     */
     @Override
     public boolean isOutContentProcessed(String location) {
 
@@ -763,10 +709,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#processIn(java.lang.String,
-     *                          java.util.Map, java.lang.Object[])
-     */
     @Override
     public void processIn(String location, Map<String, ?> headers, Object... values) {
         if (log.isLoggable(Level.FINEST)) {
@@ -789,10 +731,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#processOut(java.lang.String,
-     *                                      java.util.Map, java.lang.Object[])
-     */
     @Override
     public void processOut(String location, Map<String, ?> headers, Object... values) {
         if (log.isLoggable(Level.FINEST)) {
@@ -818,10 +756,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#setFault(java.lang.String,
-     *                  java.lang.String)
-     */
     @Override
     public void setFault(String location, String value) {
         if (log.isLoggable(Level.FINEST)) {
@@ -843,10 +777,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#setProperty(java.lang.String,
-     *                                      java.lang.String, java.lang.String)
-     */
     @Override
     public void setProperty(String location, String name, String value) {
         if (log.isLoggable(Level.FINEST)) {
@@ -870,10 +800,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#setDetail(java.lang.String,
-     *                                      java.lang.String, java.lang.String, java.lang.String, boolean)
-     */
     @Override
     public void setDetail(String location, String name, String value, String nodeType, boolean onStack) {
         if (log.isLoggable(Level.FINEST)) {
@@ -916,10 +842,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#initInBuffer(java.lang.String,
-     *                                       java.lang.Object)
-     */
     @Override
     public void initInBuffer(String location, Object obj) {
         if (log.isLoggable(Level.FINEST)) {
@@ -954,10 +876,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return obj.hashCode();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#isInBufferActive(java.lang.String,
-     *                                      java.lang.Object)
-     */
     @Override
     public boolean isInBufferActive(String location, Object obj) {
         try {
@@ -984,10 +902,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#appendInBuffer(java.lang.String,
-     *                                  java.lang.Object, byte[], int, int)
-     */
     @Override
     public void appendInBuffer(String location, Object obj, byte[] data, int offset, int len) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1014,10 +928,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#recordInBuffer(java.lang.String,
-     *                                      java.lang.Object)
-     */
     @Override
     public void recordInBuffer(String location, Object obj) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1053,10 +963,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#initOutBuffer(java.lang.String,
-     *                              java.lang.Object)
-     */
     @Override
     public void initOutBuffer(String location, Object obj) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1078,10 +984,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#isOutBufferActive(java.lang.String,
-     *                                      java.lang.Object)
-     */
     @Override
     public boolean isOutBufferActive(String location, Object obj) {
         try {
@@ -1108,10 +1010,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#appendOutBuffer(java.lang.String,
-     *                          java.lang.Object, byte[], int, int)
-     */
     @Override
     public void appendOutBuffer(String location, Object obj, byte[] data, int offset, int len) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1138,10 +1036,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.TraceCollector#recordOutBuffer(java.lang.String,
-     *                                      java.lang.Object)
-     */
     @Override
     public void recordOutBuffer(String location, Object obj) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1373,17 +1267,11 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#activate(java.lang.String,java.lang.String)
-     */
     @Override
     public boolean activate(String uri, String  operation) {
         return activate(uri, operation, null);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#activate(java.lang.String,java.lang.String,java.lang.String)
-     */
     @Override
     public boolean activate(String uri, String operation, String id) {
         if (!reporter.isEnabled()) {
@@ -1468,9 +1356,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return active;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#isActive()
-     */
     @Override
     public boolean isActive() {
         try {
@@ -1484,9 +1369,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#deactivate()
-     */
     @Override
     public void deactivate() {
         try {
@@ -1500,9 +1382,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.TraceCollector#retainNode(java.lang.String)
-     */
     @Override
     public void retainNode(String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1522,9 +1401,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.TraceCollector#releaseNode(java.lang.String)
-     */
     @Override
     public void releaseNode(String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1547,9 +1423,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.TraceCollector#retrieveNode(java.lang.String)
-     */
     @Override
     public Node retrieveNode(String id) {
         Node ret = null;
@@ -1573,9 +1446,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#initiateCorrelation(java.lang.String)
-     */
     @Override
     public void initiateCorrelation(String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1615,9 +1485,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#isCorrelated(java.lang.String)
-     */
     @Override
     public boolean isCorrelated(String id) {
         boolean correlationActive = correlations.containsKey(id);
@@ -1627,9 +1494,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return correlationActive;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#correlate(java.lang.String)
-     */
     @Override
     public void correlate(String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1649,9 +1513,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#completeCorrelation(java.lang.String, boolean)
-     */
     @Override
     public void completeCorrelation(String id, boolean allowSpawn) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1772,9 +1633,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         pop(location, spawnedBuilder, Consumer.class, uri);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#unlink()
-     */
     @Override
     public void unlink() {
         if (log.isLoggable(Level.FINEST)) {
@@ -1792,9 +1650,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#suppress()
-     */
     @Override
     public void suppress() {
         FragmentBuilder builder = fragmentManager.getFragmentBuilder();
@@ -1804,9 +1659,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#ignoreNode()
-     */
     @Override
     public void ignoreNode() {
         FragmentBuilder builder = fragmentManager.getFragmentBuilder();
@@ -1816,9 +1668,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.SessionManager#assertComplete()
-     */
     @Override
     public void assertComplete() {
         if (log.isLoggable(Level.FINEST)) {
@@ -1846,9 +1695,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#setState(java.lang.Object, java.lang.String, java.lang.Object, boolean)
-     */
     @Override
     public void setState(Object context, String name, Object value, boolean session) {
         if (log.isLoggable(Level.FINEST)) {
@@ -1873,9 +1719,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#getState(java.lang.Object, java.lang.String, boolean)
-     */
     @Override
     public Object getState(Object context, String name, boolean session) {
         Object ret = null;
@@ -1908,9 +1751,6 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.TraceCollector#session()
-     */
     @Override
     public SessionManager session() {
         return this;

--- a/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/FragmentBuilder.java
+++ b/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/FragmentBuilder.java
@@ -679,9 +679,6 @@ public class FragmentBuilder {
             this.position = position;
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#toString()
-         */
         @Override
         public String toString() {
             return "NodePlaceholder [node=" + node + ", position=" + position + "]";

--- a/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollectorTest.java
+++ b/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollectorTest.java
@@ -56,17 +56,11 @@ import org.junit.Test;
  */
 public class DefaultTraceCollectorTest {
 
-    /**  */
     private static final String BTXN_PRINCIPAL = "BTxnPrincipal";
-    /**  */
     private static final String BTXN_NAME = "BTxnName";
-    /**  */
     private static final String TEST_TENANT = "TestTenant";
-    /**  */
     private static final String TYPE = "TestType";
-    /**  */
     private static final String URI = "TestURI";
-    /**  */
     private static final String OP = "TestOP";
 
     @Test
@@ -1032,52 +1026,33 @@ public class DefaultTraceCollectorTest {
         private List<Trace> businessTransactions = new ArrayList<Trace>();
         private String tenantId;
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.TracePublisher#publish(java.lang.String, java.util.List)
-         */
         @Override
         public void publish(String tenantId, List<Trace> traces) throws Exception {
             this.tenantId = tenantId;
             businessTransactions.addAll(traces);
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List, int, long)
-         */
         @Override
         public void publish(String tenantId, List<Trace> items, int retryCount, long delay)
                                     throws Exception {
             publish(tenantId, items);
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
-         */
         @Override
         public void retry(String tenantId, List<Trace> items, String subscriber, int retryCount, long delay)
                 throws Exception {
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.TraceService#getFragment(java.lang.String, java.lang.String)
-         */
         @Override
         public Trace getFragment(String tenantId, String id) {
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.TraceService#getTrace(java.lang.String, java.lang.String)
-         */
         @Override
         public Trace getTrace(String tenantId, String id) {
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.TraceService#query(java.lang.String,
-         *              org.hawkular.apm.api.services.Criteria)
-         */
         @Override
         public List<Trace> searchFragments(String tenantId, Criteria criteria) {
             return null;
@@ -1111,35 +1086,22 @@ public class DefaultTraceCollectorTest {
             this.tenantId = tenantId;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.BusinessTransactionService#storeBusinessTransactions(java.lang.String,
-         *                              java.util.List)
-         */
         @Override
         public void storeFragments(String tenantId, List<Trace> businessTransactions)
                 throws StoreException {
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.BusinessTransactionService#clear(java.lang.String)
-         */
         @Override
         public void clear(String tenantId) {
             // TODO Auto-generated method stub
 
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.Publisher#getInitialRetryCount()
-         */
         @Override
         public int getInitialRetryCount() {
             return 0;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.Publisher#setMetricHandler(org.hawkular.apm.api.services.PublisherMetricHandler)
-         */
         @Override
         public void setMetricHandler(PublisherMetricHandler<Trace> handler) {
         }
@@ -1195,9 +1157,6 @@ public class DefaultTraceCollectorTest {
             return null;
         }
 
-        /* (non-Javadoc)
-         * @see org.hawkular.apm.api.services.ConfigurationService#clear(java.lang.String)
-         */
         @Override
         public void clear(String tenantId) {
             // TODO Auto-generated method stub

--- a/client/config-service-rest-client/src/main/java/org/hawkular/apm/config/service/rest/client/ConfigurationServiceRESTClient.java
+++ b/client/config-service-rest-client/src/main/java/org/hawkular/apm/config/service/rest/client/ConfigurationServiceRESTClient.java
@@ -57,10 +57,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         super(PropertyUtil.HAWKULAR_APM_URI_SERVICES);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getCollector(java.lang.String,
-     *                                  java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public CollectorConfiguration getCollector(String tenantId, String type, String host, String server) {
 
@@ -102,10 +98,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         return cc;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransaction(java.lang.String,
-     *              java.lang.String, org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig)
-     */
     @Override
     public List<ConfigMessage> setBusinessTransaction(String tenantId, String name, BusinessTxnConfig config) {
         return withJsonPayloadAndResults(
@@ -117,9 +109,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         );
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransactions(java.lang.String, java.util.Map)
-     */
     @Override
     public List<ConfigMessage> setBusinessTransactions(String tenantId, Map<String, BusinessTxnConfig> configs) {
         return withJsonPayloadAndResults(
@@ -131,10 +120,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         );
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#validateBusinessTransaction(
-     *                  org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig)
-     */
     @Override
     public List<ConfigMessage> validateBusinessTransaction(BusinessTxnConfig config) {
         if (!isAvailable()) {
@@ -153,10 +138,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         );
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransaction(java.lang.String,
-     *                          java.lang.String)
-     */
     @Override
     public BusinessTxnConfig getBusinessTransaction(String tenantId, String name) {
         if (!isAvailable()) {
@@ -170,9 +151,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         return getResultsForUrl(tenantId, BUSINESS_TXN_CONFIG_TYPE_REFERENCE, url, name);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactionSummaries(java.lang.String)
-     */
     @Override
     public List<BusinessTxnSummary> getBusinessTransactionSummaries(String tenantId) {
         if (!isAvailable()) {
@@ -186,9 +164,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         return getResultsForUrl(tenantId, BTXN_SUMMARY_LIST, url);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactions(java.lang.String, long)
-     */
     @Override
     public Map<String, BusinessTxnConfig> getBusinessTransactions(String tenantId, long updated) {
         if (!isAvailable()) {
@@ -202,10 +177,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         return getResultsForUrl(tenantId, BUSINESS_TXN_MAP, url, updated);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#removeBusinessTransaction(java.lang.String,
-     *                          java.lang.String)
-     */
     @Override
     public void removeBusinessTransaction(String tenantId, String name) {
         if (!isAvailable()) {
@@ -238,9 +209,6 @@ public class ConfigurationServiceRESTClient extends AbstractRESTClient implement
         });
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#clear(java.lang.String)
-     */
     @Override
     public void clear(String tenantId) {
         if (!isAvailable()) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/RuleHelper.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/RuleHelper.java
@@ -43,7 +43,6 @@ import org.jboss.byteman.rule.helper.Helper;
  */
 public class RuleHelper extends Helper implements SessionManager {
 
-    /**  */
     public static final String BINARY_SQL_MARKER = "<binary>";
 
     private static final Logger log = Logger.getLogger(RuleHelper.class.getName());
@@ -327,65 +326,41 @@ public class RuleHelper extends Helper implements SessionManager {
         return (headersAccessors.get(type));
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#activate(java.lang.String,java.lang.String,java.lang.String)
-     */
     @Override
     public boolean activate(String uri, String operation, String id) {
         return collector().session().activate(uri, operation, id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#activate(java.lang.String,java.lang.String)
-     */
     @Override
     public boolean activate(String uri, String operation) {
         return collector().session().activate(uri, operation);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#isActive()
-     */
     @Override
     public boolean isActive() {
         return collector().session().isActive();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#deactivate()
-     */
     @Override
     public void deactivate() {
         collector().session().deactivate();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#retainNode(java.lang.String)
-     */
     @Override
     public void retainNode(String id) {
         collector().session().retainNode(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#releaseNode(java.lang.String)
-     */
     @Override
     public void releaseNode(String id) {
         collector().session().releaseNode(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#retrieveNode(java.lang.String)
-     */
     @Override
     public Node retrieveNode(String id) {
         return collector().session().retrieveNode(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#initiateCorrelation(java.lang.String)
-     */
     @Override
     public void initiateCorrelation(String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -394,17 +369,11 @@ public class RuleHelper extends Helper implements SessionManager {
         collector().session().initiateCorrelation(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#isCorrelated(java.lang.String)
-     */
     @Override
     public boolean isCorrelated(String id) {
         return collector().session().isCorrelated(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#correlate(java.lang.String)
-     */
     @Override
     public void correlate(String id) {
         if (log.isLoggable(Level.FINEST)) {
@@ -413,9 +382,6 @@ public class RuleHelper extends Helper implements SessionManager {
         collector().session().correlate(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#completeCorrelation(java.lang.String, boolean)
-     */
     @Override
     public void completeCorrelation(String id, boolean allowSpawn) {
         if (log.isLoggable(Level.FINEST)) {
@@ -425,9 +391,6 @@ public class RuleHelper extends Helper implements SessionManager {
         collector().session().completeCorrelation(id, allowSpawn);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#unlink()
-     */
     @Override
     public void unlink() {
         if (log.isLoggable(Level.FINEST)) {
@@ -436,9 +399,6 @@ public class RuleHelper extends Helper implements SessionManager {
         collector().session().unlink();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#suppress()
-     */
     @Override
     public void suppress() {
         if (log.isLoggable(Level.FINEST)) {
@@ -447,9 +407,6 @@ public class RuleHelper extends Helper implements SessionManager {
         collector().session().suppress();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#ignoreNode()
-     */
     @Override
     public void ignoreNode() {
         if (log.isLoggable(Level.FINEST)) {
@@ -458,9 +415,6 @@ public class RuleHelper extends Helper implements SessionManager {
         collector().session().ignoreNode();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#assertComplete()
-     */
     @Override
     public void assertComplete() {
         if (log.isLoggable(Level.FINEST)) {
@@ -691,10 +645,6 @@ public class RuleHelper extends Helper implements SessionManager {
         return new InstrumentedInputStream(collector(), Direction.Out, is);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#setState(java.lang.Object, java.lang.String,
-     *                          java.lang.Object, boolean)
-     */
     @Override
     public void setState(Object context, String name, Object value, boolean session) {
         if (log.isLoggable(Level.FINEST)) {
@@ -704,9 +654,6 @@ public class RuleHelper extends Helper implements SessionManager {
         collector().session().setState(context, name, value, session);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.client.api.SessionManager#getState(java.lang.Object, java.lang.String, boolean)
-     */
     @Override
     public Object getState(Object context, String name, boolean session) {
         if (log.isLoggable(Level.FINEST)) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/faults/SOAPFaultDescriptor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/faults/SOAPFaultDescriptor.java
@@ -25,25 +25,16 @@ import javax.xml.soap.SOAPFault;
  */
 public class SOAPFaultDescriptor implements FaultDescriptor {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.faults.FaultDescriptor#isValid(java.lang.Object)
-     */
     @Override
     public boolean isValid(Object fault) {
         return fault instanceof SOAPFault;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.faults.FaultDescriptor#getName(java.lang.Object)
-     */
     @Override
     public String getName(Object fault) {
         return ((SOAPFault)fault).getFaultCode();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.faults.FaultDescriptor#getDescription(java.lang.Object)
-     */
     @Override
     public String getDescription(Object fault) {
         return ((SOAPFault)fault).getFaultString();

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/faults/ThrowableFaultDescriptor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/faults/ThrowableFaultDescriptor.java
@@ -23,25 +23,16 @@ package org.hawkular.apm.instrumenter.faults;
  */
 public class ThrowableFaultDescriptor implements FaultDescriptor {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.faults.FaultDescriptor#isValid(java.lang.Object)
-     */
     @Override
     public boolean isValid(Object fault) {
         return fault instanceof Throwable;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.faults.FaultDescriptor#getName(java.lang.Object)
-     */
     @Override
     public String getName(Object fault) {
         return fault.getClass().getSimpleName();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.faults.FaultDescriptor#getDescription(java.lang.Object)
-     */
     @Override
     public String getDescription(Object fault) {
         return ((Throwable)fault).getMessage();

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/ApacheHttpclientHeadersAccessor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/ApacheHttpclientHeadersAccessor.java
@@ -33,20 +33,13 @@ public class ApacheHttpclientHeadersAccessor implements HeadersAccessor {
 
     private static final Logger log = Logger.getLogger(ApacheHttpclientHeadersAccessor.class.getName());
 
-    /**  */
     private static final String TARGET_TYPE = "org.apache.http.HttpMessage";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getTargetType()
-     */
     @Override
     public String getTargetType() {
         return TARGET_TYPE;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getHeaders(java.lang.Object)
-     */
     @Override
     public Map<String, String> getHeaders(Object target) {
         try {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/IterableMapEntryHeadersAccessor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/IterableMapEntryHeadersAccessor.java
@@ -32,20 +32,13 @@ public class IterableMapEntryHeadersAccessor implements HeadersAccessor {
 
     private static final Logger log = Logger.getLogger(IterableMapEntryHeadersAccessor.class.getName());
 
-    /**  */
     private static final String TARGET_TYPE = "java.lang.Iterable<Map.Entry>";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getTargetType()
-     */
     @Override
     public String getTargetType() {
         return TARGET_TYPE;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getHeaders(java.lang.Object)
-     */
     @SuppressWarnings("unchecked")
     @Override
     public Map<String, String> getHeaders(Object target) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JavaxJmsHeadersAccessor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JavaxJmsHeadersAccessor.java
@@ -34,20 +34,13 @@ public class JavaxJmsHeadersAccessor implements HeadersAccessor {
 
     private static final Logger log = Logger.getLogger(JavaxJmsHeadersAccessor.class.getName());
 
-    /**  */
     private static final String TARGET_TYPE = "javax.jms.Message";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getTargetType()
-     */
     @Override
     public String getTargetType() {
         return TARGET_TYPE;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getHeaders(java.lang.Object)
-     */
     @SuppressWarnings("unchecked")
     @Override
     public Map<String, String> getHeaders(Object target) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JavaxServletHeadersAccessor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JavaxServletHeadersAccessor.java
@@ -33,20 +33,13 @@ public class JavaxServletHeadersAccessor implements HeadersAccessor {
 
     private static final Logger log = Logger.getLogger(JavaxServletHeadersAccessor.class.getName());
 
-    /**  */
     private static final String TARGET_TYPE = "javax.servlet.http.HttpServletRequest";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getTargetType()
-     */
     @Override
     public String getTargetType() {
         return TARGET_TYPE;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getHeaders(java.lang.Object)
-     */
     @SuppressWarnings("unchecked")
     @Override
     public Map<String, String> getHeaders(Object target) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JbossResteasyHeadersAccessor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JbossResteasyHeadersAccessor.java
@@ -31,20 +31,13 @@ public class JbossResteasyHeadersAccessor implements HeadersAccessor {
 
     private static final Logger log = Logger.getLogger(JbossResteasyHeadersAccessor.class.getName());
 
-    /**  */
     private static final String TARGET_TYPE = "org.jboss.resteasy.client.jaxrs.internal.ClientInvocation";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getTargetType()
-     */
     @Override
     public String getTargetType() {
         return TARGET_TYPE;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getHeaders(java.lang.Object)
-     */
     @SuppressWarnings("unchecked")
     @Override
     public Map<String, String> getHeaders(Object target) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JbossSwitchyardHeadersAccessor.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/headers/JbossSwitchyardHeadersAccessor.java
@@ -32,23 +32,15 @@ public class JbossSwitchyardHeadersAccessor implements HeadersAccessor {
 
     private static final Logger log = Logger.getLogger(JbossSwitchyardHeadersAccessor.class.getName());
 
-    /**  */
     private static final String TARGET_TYPE = "org.switchyard.Context";
 
-    /**  */
     private static final String PROPERTY_CLASS = "org.switchyard.Property";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getTargetType()
-     */
     @Override
     public String getTargetType() {
         return TARGET_TYPE;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersAccessor#getHeaders(java.lang.Object)
-     */
     @Override
     public Map<String, String> getHeaders(Object target) {
         try {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/io/InstrumentedInputStream.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/io/InstrumentedInputStream.java
@@ -52,41 +52,26 @@ public class InstrumentedInputStream extends InputStream {
         }
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#available()
-     */
     @Override
     public int available() throws IOException {
         return is.available();
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#mark(int)
-     */
     @Override
     public void mark(int readlimit) {
         is.mark(readlimit);
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#markSupported()
-     */
     @Override
     public boolean markSupported() {
         return is.markSupported();
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#read()
-     */
     @Override
     public int read() throws IOException {
         return is.read();
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#read(byte[])
-     */
     @Override
     public int read(byte[] b) throws IOException {
         int len=is.read(b);
@@ -98,9 +83,6 @@ public class InstrumentedInputStream extends InputStream {
         return len;
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#read(byte[],int,int)
-     */
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         int actuallen=is.read(b, off, len);
@@ -112,25 +94,16 @@ public class InstrumentedInputStream extends InputStream {
         return actuallen;
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#reset()
-     */
     @Override
     public void reset() throws IOException {
         is.reset();
     }
 
-    /* (non-Javadoc)
-     * @see java.io.InputStream#skip(long)
-     */
     @Override
     public long skip(long n) throws IOException {
         return is.skip(n);
     }
 
-    /* (non-Javadoc)
-     * @see java.io.OutputStream#close()
-     */
     @Override
     public void close() throws IOException {
         if (direction == Direction.In) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/io/InstrumentedOutputStream.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/io/InstrumentedOutputStream.java
@@ -66,25 +66,16 @@ public class InstrumentedOutputStream extends OutputStream {
         os.write(b, offset, len);
     }
 
-    /* (non-Javadoc)
-     * @see java.io.OutputStream#write(int)
-     */
     @Override
     public void write(int arg0) throws IOException {
         os.write(arg0);
     }
 
-    /* (non-Javadoc)
-     * @see java.io.OutputStream#flush()
-     */
     @Override
     public void flush() throws IOException {
         os.flush();
     }
 
-    /* (non-Javadoc)
-     * @see java.io.OutputStream#close()
-     */
     @Override
     public void close() throws IOException {
         if (direction == Direction.In) {

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/AssertCompleteTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/AssertCompleteTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public class AssertCompleteTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return AssertComplete.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         return "assertComplete()";

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/CollectorActionTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/CollectorActionTransformer.java
@@ -27,10 +27,6 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public abstract class CollectorActionTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRule(
-     *                  org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         // NOTE: This class could use a templating mechanism to provide the

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/CompleteCorrelationTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/CompleteCorrelationTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public class CompleteCorrelationTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return CompleteCorrelation.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         CompleteCorrelation completeAction = (CompleteCorrelation) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/CorrelateTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/CorrelateTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public class CorrelateTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return Correlate.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         Correlate correlateAction = (Correlate) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/DeactivateTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/DeactivateTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public class DeactivateTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return Deactivate.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         return "deactivate()";

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/FreeFormActionTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/FreeFormActionTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public class FreeFormActionTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return FreeFormAction.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         return ((FreeFormAction) action).getAction();

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/IgnoreNodeTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/IgnoreNodeTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public class IgnoreNodeTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return IgnoreNode.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         return "ignoreNode()";

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InitiateCorrelationTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InitiateCorrelationTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentAction;
  */
 public class InitiateCorrelationTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return InitiateCorrelation.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         InitiateCorrelation initiateAction = (InitiateCorrelation) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InstrumentComponentTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InstrumentComponentTransformer.java
@@ -27,25 +27,16 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentComponent
  */
 public class InstrumentComponentTransformer extends CollectorActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return InstrumentComponent.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getEntity()
-     */
     @Override
     protected String getEntity() {
         return "component";
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getParameters()
-     */
     @Override
     protected String[] getParameters(CollectorAction invocation) {
         String[] ret = new String[3];

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InstrumentConsumerTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InstrumentConsumerTransformer.java
@@ -28,25 +28,16 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentConsumer;
  */
 public class InstrumentConsumerTransformer extends CollectorActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return InstrumentConsumer.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentInvocationTransformer#getEntity()
-     */
     @Override
     protected String getEntity() {
         return "consumer";
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentInvocationTransformer#getParameters()
-     */
     @Override
     protected String[] getParameters(CollectorAction invocation) {
         String[] ret = new String[invocation.getDirection() == Direction.In ? 4 : 3];

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InstrumentProducerTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/InstrumentProducerTransformer.java
@@ -28,25 +28,16 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.InstrumentProducer;
  */
 public class InstrumentProducerTransformer extends CollectorActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return InstrumentProducer.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentInvocationTransformer#getEntity()
-     */
     @Override
     protected String getEntity() {
         return "producer";
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentInvocationTransformer#getParameters()
-     */
     @Override
     protected String[] getParameters(CollectorAction invocation) {
         String[] ret = new String[invocation.getDirection() == Direction.In ? 4 : 3];

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/ProcessContentTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/ProcessContentTransformer.java
@@ -27,18 +27,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.ProcessContent;
  */
 public class ProcessContentTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return ProcessContent.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         ProcessContent pcAction = (ProcessContent) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/ProcessHeadersTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/ProcessHeadersTransformer.java
@@ -27,18 +27,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.ProcessHeaders;
  */
 public class ProcessHeadersTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return ProcessHeaders.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         ProcessHeaders phAction = (ProcessHeaders) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetBusinessTransactionTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetBusinessTransactionTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.SetBusinessTransact
  */
 public class SetBusinessTransactionTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return SetBusinessTransaction.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         SetBusinessTransaction setAction = (SetBusinessTransaction) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetDetailTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetDetailTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.SetDetail;
  */
 public class SetDetailTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return SetDetail.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         SetDetail setAction = (SetDetail) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetFaultTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetFaultTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.SetFault;
  */
 public class SetFaultTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return SetFault.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         SetFault setAction = (SetFault) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetLevelTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetLevelTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.SetLevel;
  */
 public class SetLevelTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return SetLevel.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         SetLevel setAction = (SetLevel) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetPrincipalTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetPrincipalTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.SetPrincipal;
  */
 public class SetPrincipalTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return SetPrincipal.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         SetPrincipal setAction = (SetPrincipal) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetPropertyTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetPropertyTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.SetProperty;
  */
 public class SetPropertyTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return SetProperty.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         SetProperty setAction = (SetProperty) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetStateTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SetStateTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.SetState;
  */
 public class SetStateTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return SetState.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         SetState setState = (SetState) action;

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SuppressTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/SuppressTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.Suppress;
  */
 public class SuppressTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return Suppress.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         return "suppress()";

--- a/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/UnlinkTransformer.java
+++ b/client/instrumenter/src/main/java/org/hawkular/apm/instrumenter/rules/UnlinkTransformer.java
@@ -26,18 +26,11 @@ import org.hawkular.apm.api.model.config.instrumentation.jvm.Unlink;
  */
 public class UnlinkTransformer implements InstrumentActionTransformer {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#getActionType()
-     */
     @Override
     public Class<? extends InstrumentAction> getActionType() {
         return Unlink.class;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.config.InstrumentActionTransformer#convertToRuleAction(
-     *                      org.hawkular.apm.api.model.admin.InstrumentAction)
-     */
     @Override
     public String convertToRuleAction(InstrumentAction action) {
         return "unlink()";

--- a/client/instrumenter/src/test/java/org/hawkular/apm/instrumenter/TestHeadersAccessor.java
+++ b/client/instrumenter/src/test/java/org/hawkular/apm/instrumenter/TestHeadersAccessor.java
@@ -25,17 +25,11 @@ import org.hawkular.apm.instrumenter.headers.HeadersAccessor;
  */
 public class TestHeadersAccessor implements HeadersAccessor {
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.client.HeadersFactory#getTargetType()
-     */
     @Override
     public String getTargetType() {
         return TestHeadersObject.class.getName();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.instrumenter.headers.HeadersAccessor#getHeaders(java.lang.Object)
-     */
     @Override
     public Map<String, String> getHeaders(Object target) {
         return ((TestHeadersObject) target).getProperties();

--- a/client/instrumenter/src/test/java/org/hawkular/apm/instrumenter/rules/TransformerTest.java
+++ b/client/instrumenter/src/test/java/org/hawkular/apm/instrumenter/rules/TransformerTest.java
@@ -30,31 +30,18 @@ import org.junit.Test;
  */
 public class TransformerTest {
 
-    /**  */
     private static final String ANY_PARAMETERS = "*";
-    /**  */
     private static final String BIND_EXPR2 = "BindExpr2";
-    /**  */
     private static final String BIND_TYPE2 = "BindType2";
-    /**  */
     private static final String BIND_NAME2 = "BindName2";
-    /**  */
     private static final String BIND_EXPR1 = "BindExpr1";
-    /**  */
     private static final String BIND_TYPE1 = "BindType1";
-    /**  */
     private static final String BIND_NAME1 = "BindName1";
-    /**  */
     private static final String TEST_CONDITION_1 = "$1.getAttributes().contains(\"BTMID\")";
-    /**  */
     private static final String TEST_PARAM2 = "TestParam2";
-    /**  */
     private static final String TEST_PARAM1 = "TestParam1";
-    /**  */
     private static final String TEST_METHOD = "TestMethod";
-    /**  */
     private static final String TEST_CLASS = "TestClass";
-    /**  */
     private static final String TEST_RULE = "TestRule";
 
     @Test

--- a/client/kafka/src/main/java/org/hawkular/apm/client/kafka/AbstractPublisherKafka.java
+++ b/client/kafka/src/main/java/org/hawkular/apm/client/kafka/AbstractPublisherKafka.java
@@ -58,9 +58,6 @@ public abstract class AbstractPublisherKafka<T> implements Publisher<T>, Service
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ServiceStatus#isAvailable()
-     */
     @Override
     public boolean isAvailable() {
         String uri = PropertyUtil.getProperty(PropertyUtil.HAWKULAR_APM_URI_PUBLISHER,
@@ -87,25 +84,16 @@ public abstract class AbstractPublisherKafka<T> implements Publisher<T>, Service
         producer = new KafkaProducer<>(props);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#getInitialRetryCount()
-     */
     @Override
     public int getInitialRetryCount() {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List)
-     */
     @Override
     public void publish(String tenantId, List<T> items) throws Exception {
         publish(tenantId, items, getInitialRetryCount(), 0);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List, int, long)
-     */
     @Override
     public void publish(String tenantId, List<T> items, int retryCount, long delay) throws Exception {
         long startTime = 0;
@@ -139,17 +127,11 @@ public abstract class AbstractPublisherKafka<T> implements Publisher<T>, Service
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
-     */
     @Override
     public void retry(String tenantId, List<T> items, String subscriber, int retryCount, long delay) throws Exception {
         throw new UnsupportedOperationException("Retry not supported for this publisher");
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#setMetricHandler(org.hawkular.apm.api.services.PublisherMetricHandler)
-     */
     @Override
     public void setMetricHandler(PublisherMetricHandler<T> handler) {
         this.handler = handler;

--- a/client/kafka/src/main/java/org/hawkular/apm/client/kafka/TracePublisherKafka.java
+++ b/client/kafka/src/main/java/org/hawkular/apm/client/kafka/TracePublisherKafka.java
@@ -26,7 +26,6 @@ import org.hawkular.apm.api.services.TracePublisher;
  */
 public class TracePublisherKafka extends AbstractPublisherKafka<Trace> implements TracePublisher {
 
-    /**  */
     private static final String TOPIC = "Traces";
 
     /**

--- a/client/trace-publisher-rest-client/src/main/java/org/hawkular/apm/trace/publisher/rest/client/TracePublisherRESTClient.java
+++ b/client/trace-publisher-rest-client/src/main/java/org/hawkular/apm/trace/publisher/rest/client/TracePublisherRESTClient.java
@@ -42,17 +42,11 @@ public class TracePublisherRESTClient extends AbstractRESTClient implements Trac
         super(PropertyUtil.HAWKULAR_APM_URI_PUBLISHER);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#getInitialRetryCount()
-     */
     @Override
     public int getInitialRetryCount() {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TracePublisher#publish(java.lang.String, java.util.List)
-     */
     @Override
     public void publish(String tenantId, List<Trace> traces) throws Exception {
         long startTime = clock.millis();
@@ -73,25 +67,16 @@ public class TracePublisherRESTClient extends AbstractRESTClient implements Trac
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List, int, long)
-     */
     @Override
     public void publish(String tenantId, List<Trace> items, int retryCount, long delay) throws Exception {
         throw new UnsupportedOperationException("Cannot set the retry count and delay");
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
-     */
     @Override
     public void retry(String tenantId, List<Trace> items, String subscriber, int retryCount, long delay) throws Exception {
         throw new UnsupportedOperationException("Cannot retry");
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#setMetricHandler(org.hawkular.apm.api.services.PublisherMetricHandler)
-     */
     @Override
     public void setMetricHandler(PublisherMetricHandler<Trace> handler) {
         this.handler = handler;

--- a/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
+++ b/client/trace-service-rest-client/src/main/java/org/hawkular/apm/trace/service/rest/client/TraceServiceRESTClient.java
@@ -45,44 +45,27 @@ public class TraceServiceRESTClient extends AbstractRESTClient implements TraceS
         super(PropertyUtil.HAWKULAR_APM_URI_SERVICES);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#get(java.lang.String, java.lang.String)
-     */
     @Override
     public Trace getFragment(String tenantId, String id) {
         return getResultsForUrl(tenantId, TRACE, "traces/fragments/%s", id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#getTrace(java.lang.String, java.lang.String)
-     */
     @Override
     public Trace getTrace(String tenantId, String id) {
         return getResultsForUrl(tenantId, TRACE, "traces/complete/%s", id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#searchFragments(java.lang.String,
-     *                      org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public List<Trace> searchFragments(String tenantId, Criteria criteria) {
         String path = "traces/fragments/search?criteria=%s";
         return getResultsForUrl(tenantId, TRACE_LIST, path, criteria);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#storeTraces(java.lang.String,
-     *                              java.util.List)
-     */
     @Override
     public void storeFragments(String tenantId, List<Trace> traces) throws StoreException {
         throw new UnsupportedOperationException();
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#clear(java.lang.String)
-     */
     @Override
     public void clear(String tenantId) {
         clear(tenantId, "traces");

--- a/performance/server/src/test/java/org/hawkular/apm/performance/server/ServiceTest.java
+++ b/performance/server/src/test/java/org/hawkular/apm/performance/server/ServiceTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
  */
 public class ServiceTest {
 
-    /**  */
     private static final String TXN_NAME = "TestBTxnName";
 
     @Test

--- a/performance/server/src/test/java/org/hawkular/apm/performance/server/TestConfigurationService.java
+++ b/performance/server/src/test/java/org/hawkular/apm/performance/server/TestConfigurationService.java
@@ -36,74 +36,47 @@ public class TestConfigurationService implements ConfigurationService {
         collectorConfiguration = config;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getCollector(java.lang.String, java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public CollectorConfiguration getCollector(String tenantId, String type, String host, String server) {
         return collectorConfiguration;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransaction(java.lang.String, java.lang.String, org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig)
-     */
     @Override
     public List<ConfigMessage> setBusinessTransaction(String tenantId, String name, BusinessTxnConfig config)
             throws Exception {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransactions(java.lang.String, java.util.Map)
-     */
     @Override
     public List<ConfigMessage> setBusinessTransactions(String tenantId, Map<String, BusinessTxnConfig> configs)
             throws Exception {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#validateBusinessTransaction(org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig)
-     */
     @Override
     public List<ConfigMessage> validateBusinessTransaction(BusinessTxnConfig config) {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransaction(java.lang.String, java.lang.String)
-     */
     @Override
     public BusinessTxnConfig getBusinessTransaction(String tenantId, String name) {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactions(java.lang.String, long)
-     */
     @Override
     public Map<String, BusinessTxnConfig> getBusinessTransactions(String tenantId, long updated) {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactionSummaries(java.lang.String)
-     */
     @Override
     public List<BusinessTxnSummary> getBusinessTransactionSummaries(String tenantId) {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#removeBusinessTransaction(java.lang.String, java.lang.String)
-     */
     @Override
     public void removeBusinessTransaction(String tenantId, String name) throws Exception {
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#clear(java.lang.String)
-     */
     @Override
     public void clear(String tenantId) {
     }

--- a/performance/server/src/test/java/org/hawkular/apm/performance/server/TestTracePublisher.java
+++ b/performance/server/src/test/java/org/hawkular/apm/performance/server/TestTracePublisher.java
@@ -34,41 +34,26 @@ public class TestTracePublisher implements TracePublisher {
         return traces;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#getInitialRetryCount()
-     */
     @Override
     public int getInitialRetryCount() {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List)
-     */
     @Override
     public void publish(String tenantId, List<Trace> items) throws Exception {
         traces.addAll(items);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List, int, long)
-     */
     @Override
     public void publish(String tenantId, List<Trace> items, int retryCount, long delay) throws Exception {
         traces.addAll(items);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
-     */
     @Override
     public void retry(String tenantId, List<Trace> items, String subscriber, int retryCount, long delay)
             throws Exception {
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#setMetricHandler(org.hawkular.apm.api.services.PublisherMetricHandler)
-     */
     @Override
     public void setMetricHandler(PublisherMetricHandler<Trace> handler) {
     }

--- a/server/api/src/main/java/org/hawkular/apm/server/api/model/zipkin/Annotation.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/model/zipkin/Annotation.java
@@ -76,9 +76,6 @@ public class Annotation implements Serializable {
         this.endpoint = endpoint;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "Annotation [timestamp=" + timestamp + ", value=" + value + ", endpoint=" + endpoint + "]";

--- a/server/api/src/main/java/org/hawkular/apm/server/api/model/zipkin/BinaryAnnotation.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/model/zipkin/BinaryAnnotation.java
@@ -99,9 +99,6 @@ public class BinaryAnnotation implements Serializable {
         this.endpoint = endpoint;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "BinaryAnnotation [key=" + key + ", value=" + value + ", type=" + type + ", endpoint=" + endpoint + "]";

--- a/server/api/src/main/java/org/hawkular/apm/server/api/security/SecurityProviderException.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/security/SecurityProviderException.java
@@ -23,7 +23,6 @@ package org.hawkular.apm.server.api.security;
  */
 public class SecurityProviderException extends Exception {
 
-    /**  */
     private static final long serialVersionUID = 1L;
 
     public SecurityProviderException(String mesg) {

--- a/server/api/src/main/java/org/hawkular/apm/server/api/services/CacheException.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/services/CacheException.java
@@ -23,7 +23,6 @@ package org.hawkular.apm.server.api.services;
  */
 public class CacheException extends Exception {
 
-    /**  */
     private static final long serialVersionUID = 4985887160445662299L;
 
     /**

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/AbstractProcessor.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/AbstractProcessor.java
@@ -27,10 +27,8 @@ import org.hawkular.apm.api.utils.PropertyUtil;
  */
 public abstract class AbstractProcessor<T, R> implements Processor<T,R> {
 
-    /**  */
     private static final int DEFAULT_RETRY_DELAY = 2000;
 
-    /**  */
     private static final int DEFAULT_LAST_RETRY_DELAY = 10000;
 
     private long retryDelay = PropertyUtil.getPropertyAsInteger(PropertyUtil.HAWKULAR_APM_PROCESSOR_RETRY_DELAY,
@@ -50,32 +48,20 @@ public abstract class AbstractProcessor<T, R> implements Processor<T,R> {
         this.type = type;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#getType()
-     */
     @Override
     public org.hawkular.apm.server.api.task.Processor.ProcessorType getType() {
         return type;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#initialise(java.lang.String,java.util.List)
-     */
     @Override
     public void initialise(String tenantId, List<T> items) throws RetryAttemptException {
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#getDeliveryDelay(java.util.List)
-     */
     @Override
     public long getDeliveryDelay(List<R> results) {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#getRetryDelay(java.util.List, int)
-     */
     @Override
     public long getRetryDelay(List<T> items, int retryCount) {
         if (retryCount == 0) {
@@ -84,41 +70,26 @@ public abstract class AbstractProcessor<T, R> implements Processor<T,R> {
         return retryDelay;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#isReportRetryExpirationAsWarning()
-     */
     @Override
     public boolean isReportRetryExpirationAsWarning() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processOneToOne(java.lang.String, java.lang.Object)
-     */
     @Override
     public R processOneToOne(String tenantId, T item) throws RetryAttemptException {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processOneToMany(java.lang.String, java.lang.Object)
-     */
     @Override
     public List<R> processOneToMany(String tenantId, T item) throws RetryAttemptException {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processManyToMany(java.lang.String, java.util.List)
-     */
     @Override
     public List<R> processManyToMany(String tenantId, List<T> items) throws RetryAttemptException {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#cleanup(java.lang.String,java.util.List)
-     */
     @Override
     public void cleanup(String tenantId, List<T> items) {
     }

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/ProcessingUnit.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/ProcessingUnit.java
@@ -112,9 +112,6 @@ public class ProcessingUnit<T, R> implements Handler<T> {
         this.retryHandler = retryHandler;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Handler#handle(java.lang.String,java.util.List)
-     */
     @Override
     public void handle(String tenantId, List<T> items) throws Exception {
         List<R> results = null;

--- a/server/api/src/main/java/org/hawkular/apm/server/api/task/RetryAttemptException.java
+++ b/server/api/src/main/java/org/hawkular/apm/server/api/task/RetryAttemptException.java
@@ -24,7 +24,6 @@ package org.hawkular.apm.server.api.task;
  */
 public class RetryAttemptException extends Exception {
 
-    /**  */
     private static final long serialVersionUID = -9183048971847453822L;
 
     /**

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ConfigurationServiceElasticsearch.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ConfigurationServiceElasticsearch.java
@@ -52,20 +52,16 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
 
     private final MsgLogger msgLog = MsgLogger.LOGGER;
 
-    /**  */
     private static final String BUSINESS_TXN_CONFIG_TYPE = "businesstxnconfig";
 
-    /**  */
     private static final String BUSINESS_TXN_CONFIG_INVALID_TYPE = "businesstxnconfiginvalid";
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private ElasticsearchClient client = ElasticsearchClient.getSingleton();
 
-    /**  */
     private static int DEFAULT_RESPONSE_SIZE = 100000;
 
-    /**  */
     private static long DEFAULT_TIMEOUT = 10000L;
 
     private long timeout = DEFAULT_TIMEOUT;
@@ -102,10 +98,6 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
         this.client = client;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getCollector(java.lang.String,
-     *                          java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public CollectorConfiguration getCollector(String tenantId, String type, String host, String server) {
         CollectorConfiguration config = ConfigurationLoader.getConfiguration(type);
@@ -150,10 +142,6 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
         return config;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#setBusinessTransaction(java.lang.String,
-     *              java.lang.String, org.hawkular.apm.api.model.config.btxn.BusinessTxnConfig)
-     */
     @Override
     public List<ConfigMessage> setBusinessTransaction(String tenantId, String name, BusinessTxnConfig config)
             throws Exception {
@@ -196,10 +184,6 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
         return messages;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransaction(java.lang.String,
-     *                  java.lang.String)
-     */
     @Override
     public BusinessTxnConfig getBusinessTransaction(String tenantId, String name) {
         BusinessTxnConfig ret = null;
@@ -257,9 +241,6 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactionSummaries(java.lang.String)
-     */
     @Override
     public List<BusinessTxnSummary> getBusinessTransactionSummaries(String tenantId) {
         List<BusinessTxnSummary> ret = new ArrayList<BusinessTxnSummary>();
@@ -337,9 +318,6 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#getBusinessTransactions(java.lang.String, long)
-     */
     @Override
     public Map<String, BusinessTxnConfig> getBusinessTransactions(String tenantId, long updated) {
         Map<String, BusinessTxnConfig> ret = new HashMap<String, BusinessTxnConfig>();
@@ -383,10 +361,6 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ConfigurationService#removeBusinessTransaction(java.lang.String,
-     *                          java.lang.String)
-     */
     @Override
     public void removeBusinessTransaction(String tenantId, String name) throws Exception {
         BusinessTxnConfig config = new BusinessTxnConfig();
@@ -411,9 +385,6 @@ public class ConfigurationServiceElasticsearch extends AbstractConfigurationServ
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#clearTenant(java.lang.String)
-     */
     @Override
     public void clear(String tenantId) {
         client.clearTenant(tenantId);

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchClient.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchClient.java
@@ -48,7 +48,6 @@ import org.hawkular.apm.api.utils.PropertyUtil;
  */
 public class ElasticsearchClient {
 
-    /**  */
     private static final String HAWKULAR_APM_MAPPING_JSON = "hawkular-apm-mapping.json";
 
     /**

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchEmbeddedNode.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchEmbeddedNode.java
@@ -39,7 +39,6 @@ import org.elasticsearch.node.NodeBuilder;
  */
 public final class ElasticsearchEmbeddedNode {
 
-    /**  */
     private static final String HAWKULAR_ELASTICSEARCH_PROPERTIES = "hawkular-elasticsearch.properties";
 
     private static final Logger log = Logger.getLogger(ElasticsearchEmbeddedNode.class.getName());

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/TraceServiceElasticsearch.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/TraceServiceElasticsearch.java
@@ -69,24 +69,15 @@ public class TraceServiceElasticsearch implements TraceService {
 
     private static final MsgLogger msgLog = MsgLogger.LOGGER;
 
-    /**  */
     private static final String START_TIME_FIELD = "startTime";
-    /**  */
     private static final String NODES_FIELD = "nodes";
-    /**  */
     private static final String PRINCIPAL_FIELD = "principal";
-    /**  */
     private static final String ID_FIELD = "id";
-    /**  */
     private static final String HOST_NAME_FIELD = "hostName";
-    /**  */
     private static final String HOST_ADDRESS_FIELD = "hostAddress";
-    /**  */
     private static final String BUSINESS_TRANSACTION_FIELD = "businessTransaction";
-    /**  */
     private static final String PROPERTIES_FIELD = "properties";
 
-    /**  */
     public static final String TRACE_TYPE = "trace";
 
     private static final ObjectMapper mapper = new ObjectMapper();
@@ -127,9 +118,6 @@ public class TraceServiceElasticsearch implements TraceService {
         this.client = client;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#getFragment(java.lang.String, java.lang.String)
-     */
     @Override
     public Trace getFragment(String tenantId, String id) {
         Trace ret = null;
@@ -153,9 +141,6 @@ public class TraceServiceElasticsearch implements TraceService {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#getTrace(java.lang.String, java.lang.String)
-     */
     @Override
     public Trace getTrace(String tenantId, String id) {
         Trace ret = getFragment(tenantId, id);
@@ -236,10 +221,6 @@ public class TraceServiceElasticsearch implements TraceService {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#searchFragments(java.lang.String,
-     *          org.hawkular.apm.api.services.Criteria)
-     */
     @Override
     public List<Trace> searchFragments(String tenantId, Criteria criteria) {
         return internalQuery(client, tenantId, criteria);
@@ -313,10 +294,6 @@ public class TraceServiceElasticsearch implements TraceService {
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.TraceService#storeTraces(java.lang.String,
-     *                              java.util.List)
-     */
     @Override
     public void storeFragments(String tenantId, List<Trace> traces)
             throws StoreException {
@@ -358,9 +335,6 @@ public class TraceServiceElasticsearch implements TraceService {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.AnalyticsService#clearTenant(java.lang.String)
-     */
     @Override
     public void clear(String tenantId) {
         client.clearTenant(tenantId);
@@ -368,10 +342,6 @@ public class TraceServiceElasticsearch implements TraceService {
 
     public static class TraceSerializer extends JsonSerializer<Trace> {
 
-        /* (non-Javadoc)
-         * @see com.fasterxml.jackson.databind.JsonSerializer#serialize(java.lang.Object,
-         *          com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
-         */
         @Override
         public void serialize(Trace trace, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException, JsonProcessingException {
@@ -399,9 +369,6 @@ public class TraceServiceElasticsearch implements TraceService {
 
     public static class TraceDeserializer extends JsonDeserializer<Trace> {
 
-        /* (non-Javadoc)
-         * @see com.fasterxml.jackson.databind.JsonDeserializer#deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
-         */
         @Override
         public Trace deserialize(JsonParser parser, DeserializationContext context)
                 throws IOException, JsonProcessingException {

--- a/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/ConfigurationServiceElasticsearchTest.java
+++ b/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/ConfigurationServiceElasticsearchTest.java
@@ -44,10 +44,8 @@ import org.mockito.Mockito;
  */
 public class ConfigurationServiceElasticsearchTest {
 
-    /**  */
     private static final String VALID_DESCRIPTION = "Valid description";
 
-    /**  */
     private static final String INVALID_DESCRIPTION = "Invalid description";
     private ConfigurationServiceElasticsearch cfgs;
     private Clock clock = Mockito.mock(Clock.class);

--- a/server/infinispan/src/main/java/org/hawkular/apm/server/infinispan/InfinispanCommunicationDetailsCache.java
+++ b/server/infinispan/src/main/java/org/hawkular/apm/server/infinispan/InfinispanCommunicationDetailsCache.java
@@ -44,10 +44,8 @@ public class InfinispanCommunicationDetailsCache implements CommunicationDetails
 
     private static final Logger log = Logger.getLogger(InfinispanCommunicationDetailsCache.class.getName());
 
-    /**  */
     protected static final String CACHE_NAME = "communicationdetails";
 
-    /**  */
     protected static final String MULTI_CONSUMER_CACHE_NAME = "communicationdetailsMulticonsumer";
 
     @Resource(lookup = "java:jboss/infinispan/APM")
@@ -87,10 +85,6 @@ public class InfinispanCommunicationDetailsCache implements CommunicationDetails
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.btxncompletiontime.CommunicationDetailsCache#get(
-     *                      java.lang.String, java.lang.String)
-     */
     @Override
     public CommunicationDetails get(String tenantId, String id) {
         CommunicationDetails ret = communicationDetails.get(id);
@@ -102,10 +96,6 @@ public class InfinispanCommunicationDetailsCache implements CommunicationDetails
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.btxncompletiontime.CommunicationDetailsCache#store(java.lang.String,
-     *                      java.util.List)
-     */
     @Override
     public void store(String tenantId, List<CommunicationDetails> details) throws CacheException {
         if (cacheContainer != null) {

--- a/server/infinispan/src/main/java/org/hawkular/apm/server/infinispan/InfinispanSourceInfoCache.java
+++ b/server/infinispan/src/main/java/org/hawkular/apm/server/infinispan/InfinispanSourceInfoCache.java
@@ -39,7 +39,6 @@ import org.infinispan.manager.CacheContainer;
 @Singleton
 public class InfinispanSourceInfoCache implements SourceInfoCache, ServiceLifecycle {
 
-    /**  */
     private static final String CACHE_NAME = "sourceinfo";
 
     private static final Logger log = Logger.getLogger(InfinispanSourceInfoCache.class.getName());
@@ -73,9 +72,6 @@ public class InfinispanSourceInfoCache implements SourceInfoCache, ServiceLifecy
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.communicationdetails.SourceInfoCache#get(java.lang.String, java.lang.String)
-     */
     @Override
     public SourceInfo get(String tenantId, String id) {
         SourceInfo ret = sourceInfo.get(id);
@@ -87,9 +83,6 @@ public class InfinispanSourceInfoCache implements SourceInfoCache, ServiceLifecy
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.communicationdetails.SourceInfoCache#store(java.lang.String, java.util.List)
-     */
     @Override
     public void store(String tenantId, List<SourceInfo> sourceInfoList) {
         if (cacheContainer != null) {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/AbstractPublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/AbstractPublisherJMS.java
@@ -61,9 +61,6 @@ public abstract class AbstractPublisherJMS<T> implements Publisher<T>, ServiceLi
     private int initialRetryCount = PropertyUtil.getPropertyAsInteger(
             PropertyUtil.HAWKULAR_APM_PROCESSOR_MAX_RETRY_COUNT, DEFAULT_INITIAL_RETRY_COUNT);
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.ServiceStatus#isAvailable()
-     */
     @Override
     public boolean isAvailable() {
         // If no publisher is defined, then this is the default implementation
@@ -144,25 +141,16 @@ public abstract class AbstractPublisherJMS<T> implements Publisher<T>, ServiceLi
         producer.send(tm);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List, long)
-     */
     @Override
     public void publish(String tenantId, List<T> items, int retryCount, long delay) throws Exception {
         doPublish(tenantId, items, null, retryCount, delay);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#publish(java.lang.String, java.util.List)
-     */
     @Override
     public void publish(String tenantId, List<T> items) throws Exception {
         doPublish(tenantId, items, null, getInitialRetryCount(), 0);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#retry(java.lang.String, java.util.List, java.lang.String, int, long)
-     */
     @Override
     public void retry(String tenantId, List<T> items, String subscriber, int retryCount, long delay) throws Exception {
         doPublish(tenantId, items, subscriber, retryCount, delay);
@@ -182,9 +170,6 @@ public abstract class AbstractPublisherJMS<T> implements Publisher<T>, ServiceLi
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.api.services.Publisher#setMetricHandler(org.hawkular.apm.api.services.PublisherMetricHandler)
-     */
     @Override
     public void setMetricHandler(PublisherMetricHandler<T> handler) {
     }

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsCacheMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsCacheMDB.java
@@ -59,7 +59,6 @@ public class CommunicationDetailsCacheMDB extends RetryCapableMDB<CommunicationD
     @Inject
     private CommunicationDetailsCache communicationDetailsCache;
 
-    /**  */
     public static final String SUBSCRIBER = "CommunicationDetailsCache";
 
     public CommunicationDetailsCacheMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsPublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsPublisherJMS.java
@@ -29,9 +29,6 @@ public class CommunicationDetailsPublisherJMS extends AbstractPublisherJMS<Commu
 
     private static final String DESTINATION = "java:/CommunicationDetails";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/CommunicationDetailsStoreMDB.java
@@ -52,7 +52,6 @@ public class CommunicationDetailsStoreMDB extends RetryCapableMDB<CommunicationD
     @Inject
     private AnalyticsService analyticsService;
 
-    /**  */
     public static final String SUBSCRIBER = "CommunicationDetailsStore";
 
     public CommunicationDetailsStoreMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimePublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimePublisherJMS.java
@@ -29,9 +29,6 @@ public class FragmentCompletionTimePublisherJMS extends AbstractPublisherJMS<Com
 
     private static final String DESTINATION = "java:/FragmentCompletionTimes";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/FragmentCompletionTimeStoreMDB.java
@@ -52,7 +52,6 @@ public class FragmentCompletionTimeStoreMDB extends RetryCapableMDB<CompletionTi
     @Inject
     private AnalyticsService analyticsService;
 
-    /**  */
     public static final String SUBSCRIBER = "FragmentCompletionTimeStore";
 
     public FragmentCompletionTimeStoreMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsPublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsPublisherJMS.java
@@ -29,9 +29,6 @@ public class NodeDetailsPublisherJMS extends AbstractPublisherJMS<NodeDetails>
 
     private static final String DESTINATION = "java:/NodeDetails";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/NodeDetailsStoreMDB.java
@@ -52,7 +52,6 @@ public class NodeDetailsStoreMDB extends RetryCapableMDB<NodeDetails, Void> {
     @Inject
     private AnalyticsService analyticsService;
 
-    /**  */
     public static final String SUBSCRIBER = "NodeDetailsStore";
 
     public NodeDetailsStoreMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/NotificationPublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/NotificationPublisherJMS.java
@@ -29,9 +29,6 @@ public class NotificationPublisherJMS extends AbstractPublisherJMS<Notification>
 
     private static final String DESTINATION = "java:/Notifications";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/RetryCapableMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/RetryCapableMDB.java
@@ -60,7 +60,6 @@ public abstract class RetryCapableMDB<S,T> implements MessageListener {
 
     private String retrySubscriber;
 
-    /**  */
     private static final int DEFAULT_MAX_RETRY_COUNT = 3;
 
     private int maxRetryCount = PropertyUtil.getPropertyAsInteger(PropertyUtil.HAWKULAR_APM_PROCESSOR_MAX_RETRY_COUNT,
@@ -131,9 +130,6 @@ public abstract class RetryCapableMDB<S,T> implements MessageListener {
         this.typeReference = typeReference;
     }
 
-    /* (non-Javadoc)
-     * @see javax.jms.MessageListener#onMessage(javax.jms.Message)
-     */
     @Override
     public void onMessage(Message message) {
         if (log.isLoggable(Level.FINEST)) {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimePublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimePublisherJMS.java
@@ -29,9 +29,6 @@ public class TraceCompletionTimePublisherJMS extends AbstractPublisherJMS<Comple
 
     private static final String DESTINATION = "java:/TraceCompletionTimes";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimeStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/TraceCompletionTimeStoreMDB.java
@@ -52,7 +52,6 @@ public class TraceCompletionTimeStoreMDB extends RetryCapableMDB<CompletionTime,
     @Inject
     private AnalyticsService analyticsService;
 
-    /**  */
     public static final String SUBSCRIBER = "TraceCompletionTimeStore";
 
     public TraceCompletionTimeStoreMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/CommunicationDetailsDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/CommunicationDetailsDeriverMDB.java
@@ -56,7 +56,6 @@ public class CommunicationDetailsDeriverMDB extends RetryCapableMDB<Span, Commun
     @Inject
     private SpanCache spanCache;
 
-    /**  */
     public static final String SUBSCRIBER = "SpanCommunicationDetailsDeriver";
 
     public CommunicationDetailsDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/FragmentCompletionTimeDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/FragmentCompletionTimeDeriverMDB.java
@@ -57,7 +57,6 @@ public class FragmentCompletionTimeDeriverMDB extends RetryCapableMDB<Span, Comp
     @Inject
     private FragmentCompletionTimePublisherJMS fragmentCompletionTimePublisher;
 
-    /**  */
     public static final String SUBSCRIBER = "SpanFragmentCompletionTimeDeriver";
 
     public FragmentCompletionTimeDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/NodeDetailsDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/NodeDetailsDeriverMDB.java
@@ -51,7 +51,6 @@ public class NodeDetailsDeriverMDB extends RetryCapableMDB<Span, NodeDetails> {
     @Inject
     private NodeDetailsPublisherJMS nodeDetailsPublisher;
 
-    /**  */
     public static final String SUBSCRIBER = "SpanNodeDetailsDeriver";
 
     public NodeDetailsDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/SpanCacheMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/SpanCacheMDB.java
@@ -64,9 +64,6 @@ public class SpanCacheMDB implements MessageListener {
     private TypeReference<java.util.List<Span>> typeRef = new TypeReference<java.util.List<Span>>() {
     };
 
-    /* (non-Javadoc)
-     * @see javax.jms.MessageListener#onMessage(javax.jms.Message)
-     */
     @Override
     public void onMessage(Message message) {
         if (log.isLoggable(Level.FINEST)) {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/span/SpanPublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/span/SpanPublisherJMS.java
@@ -30,9 +30,6 @@ public class SpanPublisherJMS extends AbstractPublisherJMS<Span>
 
     private static final String DESTINATION = "java:/Spans";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/CommunicationDetailsDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/CommunicationDetailsDeriverMDB.java
@@ -55,7 +55,6 @@ public class CommunicationDetailsDeriverMDB extends RetryCapableMDB<Trace, Commu
     @Inject
     private CommunicationDetailsDeriver communicationDetailsDeriver;
 
-    /**  */
     public static final String SUBSCRIBER = "CommunicationDetailsDeriver";
 
     public CommunicationDetailsDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/FragmentCompletionTimeDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/FragmentCompletionTimeDeriverMDB.java
@@ -53,7 +53,6 @@ public class FragmentCompletionTimeDeriverMDB extends RetryCapableMDB<Trace, Com
     @Inject
     private FragmentCompletionTimePublisherJMS fragmentCompletionTimePublisher;
 
-    /**  */
     public static final String SUBSCRIBER = "FragmentCompletionTimeDeriver";
 
     public FragmentCompletionTimeDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/NodeDetailsDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/NodeDetailsDeriverMDB.java
@@ -51,7 +51,6 @@ public class NodeDetailsDeriverMDB extends RetryCapableMDB<Trace, NodeDetails> {
     @Inject
     private NodeDetailsPublisherJMS nodeDetailsPublisher;
 
-    /**  */
     public static final String SUBSCRIBER = "NodeDetailsDeriver";
 
     public NodeDetailsDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/NotificationDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/NotificationDeriverMDB.java
@@ -51,7 +51,6 @@ public class NotificationDeriverMDB extends RetryCapableMDB<Trace, Notification>
     @Inject
     private NotificationPublisherJMS notificationPublisher;
 
-    /**  */
     public static final String SUBSCRIBER = "NotificationDeriver";
 
     public NotificationDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/SourceInfoCacheMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/SourceInfoCacheMDB.java
@@ -68,9 +68,6 @@ public class SourceInfoCacheMDB implements MessageListener {
     private TypeReference<java.util.List<Trace>> typeRef = new TypeReference<java.util.List<Trace>>() {
     };
 
-    /* (non-Javadoc)
-     * @see javax.jms.MessageListener#onMessage(javax.jms.Message)
-     */
     @Override
     public void onMessage(Message message) {
         if (log.isLoggable(Level.FINEST)) {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionInformationInitiatorMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionInformationInitiatorMDB.java
@@ -54,7 +54,6 @@ public class TraceCompletionInformationInitiatorMDB
     @Inject
     private TraceCompletionInformationPublisherJMS traceCompletionInformationPublisher;
 
-    /**  */
     public static final String SUBSCRIBER = "TraceCompletionInformationInitiator";
 
     public TraceCompletionInformationInitiatorMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionInformationProcessorMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionInformationProcessorMDB.java
@@ -53,7 +53,6 @@ public class TraceCompletionInformationProcessorMDB
     @Inject
     private TraceCompletionInformationProcessor traceCompletionInformationProcessor;
 
-    /**  */
     public static final String SUBSCRIBER = "TraceCompletionInformationProcessor";
 
     public TraceCompletionInformationProcessorMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionInformationPublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionInformationPublisherJMS.java
@@ -30,9 +30,6 @@ public class TraceCompletionInformationPublisherJMS extends AbstractPublisherJMS
 
     private static final String DESTINATION = "java:/TraceCompletionInformation";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionTimeDeriverMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceCompletionTimeDeriverMDB.java
@@ -53,7 +53,6 @@ public class TraceCompletionTimeDeriverMDB extends RetryCapableMDB<TraceCompleti
     @Inject
     private TraceCompletionTimePublisherJMS traceCompletionTimePublisher;
 
-    /**  */
     public static final String SUBSCRIBER = "TraceCompletionTimeDeriver";
 
     public TraceCompletionTimeDeriverMDB() {

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TracePublisherJMS.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TracePublisherJMS.java
@@ -30,9 +30,6 @@ public class TracePublisherJMS extends AbstractPublisherJMS<Trace>
 
     private static final String DESTINATION = "java:/Traces";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.jms.AbstractPublisherJMS#getDestinationURI()
-     */
     @Override
     protected String getDestinationURI() {
         return DESTINATION;

--- a/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceStoreMDB.java
+++ b/server/jms/src/main/java/org/hawkular/apm/server/jms/trace/TraceStoreMDB.java
@@ -53,7 +53,6 @@ public class TraceStoreMDB extends RetryCapableMDB<Trace, Void> {
     @Inject
     private TraceService traceService;
 
-    /**  */
     public static final String SUBSCRIBER = "TraceStore";
 
     public TraceStoreMDB() {

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsCacheKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsCacheKafka.java
@@ -42,7 +42,6 @@ public class CommunicationDetailsCacheKafka extends AbstractConsumerKafka<Commun
      * queue semantics) */
     private static final String GROUP_ID = "CommunicationDetailsCache_" + UUID.randomUUID().toString();
 
-    /**  */
     private static final String TOPIC = "CommunicationDetails";
 
     private CommunicationDetailsCache communicationDetailsCache;

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsDeriverKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsDeriverKafka.java
@@ -36,7 +36,6 @@ public class CommunicationDetailsDeriverKafka extends AbstractRetryConsumerKafka
 
     private static final String GROUP_ID = "CommunicationDetailsDeriver";
 
-    /**  */
     private static final String TOPIC = "Traces";
 
     public CommunicationDetailsDeriverKafka() {
@@ -71,9 +70,6 @@ public class CommunicationDetailsDeriverKafka extends AbstractRetryConsumerKafka
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.kafka.AbstractRetryConsumerKafka#isExpired(java.lang.Object, long)
-     */
     @Override
     protected boolean isExpired(Trace item, long currentTime) {
         // TODO Auto-generated method stub

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsPublisherKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsPublisherKafka.java
@@ -28,7 +28,6 @@ import org.hawkular.apm.server.api.services.CommunicationDetailsPublisher;
 public class CommunicationDetailsPublisherKafka extends AbstractPublisherKafka<CommunicationDetails>
         implements CommunicationDetailsPublisher {
 
-    /**  */
     private static final String TOPIC = "CommunicationDetails";
 
     /**

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsStoreKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/CommunicationDetailsStoreKafka.java
@@ -36,10 +36,8 @@ public class CommunicationDetailsStoreKafka extends AbstractConsumerKafka<Commun
 
     private static final Logger log = Logger.getLogger(CommunicationDetailsStoreKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "CommunicationDetailsStore";
 
-    /**  */
     private static final String TOPIC = "CommunicationDetails";
 
     private AnalyticsService analyticsService;

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeDeriverKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeDeriverKafka.java
@@ -33,10 +33,8 @@ public class FragmentCompletionTimeDeriverKafka extends AbstractConsumerKafka<Tr
 
     private static final Logger log = Logger.getLogger(FragmentCompletionTimeDeriverKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "FragmentCompletionTimeDeriver";
 
-    /**  */
     private static final String TOPIC = "Traces";
 
     public FragmentCompletionTimeDeriverKafka() {

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimePublisherKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimePublisherKafka.java
@@ -28,7 +28,6 @@ import org.hawkular.apm.server.api.services.FragmentCompletionTimePublisher;
 public class FragmentCompletionTimePublisherKafka extends AbstractPublisherKafka<CompletionTime>
         implements FragmentCompletionTimePublisher {
 
-    /**  */
     private static final String TOPIC = "FragmentCompletionTime";
 
     /**

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeStoreKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/FragmentCompletionTimeStoreKafka.java
@@ -36,10 +36,8 @@ public class FragmentCompletionTimeStoreKafka extends AbstractConsumerKafka<Comp
 
     private static final Logger log = Logger.getLogger(FragmentCompletionTimeStoreKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "FragmentCompletionTimeStore";
 
-    /**  */
     private static final String TOPIC = "FragmentCompletionTime";
 
     private AnalyticsService analyticsService;

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsDeriverKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsDeriverKafka.java
@@ -33,10 +33,8 @@ public class NodeDetailsDeriverKafka extends AbstractConsumerKafka<Trace, NodeDe
 
     private static final Logger log = Logger.getLogger(NodeDetailsDeriverKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "NodeDetailsDeriver";
 
-    /**  */
     private static final String TOPIC = "Traces";
 
     public NodeDetailsDeriverKafka() {

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsPublisherKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsPublisherKafka.java
@@ -27,7 +27,6 @@ import org.hawkular.apm.server.api.services.NodeDetailsPublisher;
  */
 public class NodeDetailsPublisherKafka extends AbstractPublisherKafka<NodeDetails> implements NodeDetailsPublisher {
 
-    /**  */
     private static final String TOPIC = "NodeDetails";
 
     /**

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsStoreKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/NodeDetailsStoreKafka.java
@@ -36,10 +36,8 @@ public class NodeDetailsStoreKafka extends AbstractConsumerKafka<NodeDetails, Vo
 
     private static final Logger log = Logger.getLogger(NodeDetailsStoreKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "NodeDetailsStore";
 
-    /**  */
     private static final String TOPIC = "NodeDetails";
 
     private AnalyticsService analyticsService;

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/SourceInfoCacheKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/SourceInfoCacheKafka.java
@@ -44,7 +44,6 @@ public class SourceInfoCacheKafka extends AbstractConsumerKafka<Trace, Void> {
      * queue semantics) */
     private static final String GROUP_ID = "SourceInfoCache_" + UUID.randomUUID().toString();
 
-    /**  */
     private static final String TOPIC = "Traces";
 
     private SourceInfoCache sourceInfoCache;

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationInitiatorKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationInitiatorKafka.java
@@ -34,10 +34,8 @@ public class TraceCompletionInformationInitiatorKafka
 
     private static final Logger log = Logger.getLogger(TraceCompletionInformationInitiatorKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "TraceCompletionInformationInitiator";
 
-    /**  */
     private static final String TOPIC = "Traces";
 
     public TraceCompletionInformationInitiatorKafka() {

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationProcessorKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationProcessorKafka.java
@@ -36,7 +36,6 @@ public class TraceCompletionInformationProcessorKafka
 
     private static final String GROUP_ID = "TraceCompletionInformationProcessor";
 
-    /**  */
     private static final String TOPIC = "TraceCompletionInformation";
 
     public TraceCompletionInformationProcessorKafka() {
@@ -68,9 +67,6 @@ public class TraceCompletionInformationProcessorKafka
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.kafka.AbstractRetryConsumerKafka#isExpired(java.lang.Object, long)
-     */
     @Override
     protected boolean isExpired(TraceCompletionInformation item, long currentTime) {
         // TODO Auto-generated method stub

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationPublisherKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionInformationPublisherKafka.java
@@ -28,7 +28,6 @@ import org.hawkular.apm.server.processor.tracecompletiontime.TraceCompletionInfo
 public class TraceCompletionInformationPublisherKafka extends AbstractPublisherKafka<TraceCompletionInformation>
         implements TraceCompletionInformationPublisher {
 
-    /**  */
     private static final String TOPIC = "TraceCompletionInformation";
 
     /**

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimeDeriverKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimeDeriverKafka.java
@@ -36,7 +36,6 @@ public class TraceCompletionTimeDeriverKafka
 
     private static final String GROUP_ID = "TraceCompletionTimeDeriver";
 
-    /**  */
     private static final String TOPIC = "TraceCompletionInformation";
 
     public TraceCompletionTimeDeriverKafka() {

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimePublisherKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimePublisherKafka.java
@@ -28,7 +28,6 @@ import org.hawkular.apm.server.api.services.TraceCompletionTimePublisher;
 public class TraceCompletionTimePublisherKafka extends AbstractPublisherKafka<CompletionTime>
         implements TraceCompletionTimePublisher {
 
-    /**  */
     private static final String TOPIC = "TraceCompletionTime";
 
     /**

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimeStoreKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceCompletionTimeStoreKafka.java
@@ -36,10 +36,8 @@ public class TraceCompletionTimeStoreKafka extends AbstractConsumerKafka<Complet
 
     private static final Logger log = Logger.getLogger(TraceCompletionTimeStoreKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "TraceCompletionTimeStore";
 
-    /**  */
     private static final String TOPIC = "TraceCompletionTime";
 
     private AnalyticsService analyticsService;

--- a/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceStoreKafka.java
+++ b/server/kafka/src/main/java/org/hawkular/apm/server/kafka/TraceStoreKafka.java
@@ -36,10 +36,8 @@ public class TraceStoreKafka extends AbstractConsumerKafka<Trace, Void> {
 
     private static final Logger log = Logger.getLogger(TraceStoreKafka.class.getName());
 
-    /**  */
     private static final String GROUP_ID = "TraceStore";
 
-    /**  */
     private static final String TOPIC = "Traces";
 
     private TraceService traceService;

--- a/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/NodeDetailsDeriver.java
+++ b/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/NodeDetailsDeriver.java
@@ -48,9 +48,6 @@ public class NodeDetailsDeriver extends AbstractProcessor<Span, NodeDetails> {
         super(ProcessorType.OneToOne);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
-     */
     @Override
     public NodeDetails processOneToOne(String tenantId, Span item) throws RetryAttemptException {
         NodeDetails nd = createTypedNodeDetails(item);

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriver.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriver.java
@@ -73,9 +73,6 @@ public class CommunicationDetailsDeriver extends AbstractProcessor<Trace, Commun
         this.sourceInfoCache = sourceInfoCache;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#initialise(java.util.List)
-     */
     @Override
     public void initialise(String tenantId, List<Trace> items) throws RetryAttemptException {
         List<SourceInfo> sourceInfoList = SourceInfoUtil.getSourceInfo(tenantId, items);
@@ -87,9 +84,6 @@ public class CommunicationDetailsDeriver extends AbstractProcessor<Trace, Commun
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
-     */
     @Override
     public CommunicationDetails processOneToOne(String tenantId, Trace item) throws RetryAttemptException {
         CommunicationDetails ret = null;

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
@@ -42,9 +42,6 @@ public class FragmentCompletionTimeDeriver extends AbstractProcessor<Trace, Comp
         super(ProcessorType.OneToOne);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
-     */
     @Override
     public CompletionTime processOneToOne(String tenantId, Trace item) throws RetryAttemptException {
         // Check fragment has top level node

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/nodedetails/NodeDetailsDeriver.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/nodedetails/NodeDetailsDeriver.java
@@ -50,9 +50,6 @@ public class NodeDetailsDeriver extends AbstractProcessor<Trace, NodeDetails> {
         super(ProcessorType.OneToMany);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processMultiple(java.lang.Object)
-     */
     @Override
     public List<NodeDetails> processOneToMany(String tenantId, Trace item) throws RetryAttemptException {
         List<NodeDetails> ret = new ArrayList<NodeDetails>();

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/notification/NotificationDeriver.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/notification/NotificationDeriver.java
@@ -43,9 +43,6 @@ public class NotificationDeriver extends AbstractProcessor<Trace, Notification> 
         super(ProcessorType.OneToOne);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.Object)
-     */
     @Override
     public Notification processOneToOne(String tenantId, Trace item) throws RetryAttemptException {
         // Check if named txn and has nodes

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformation.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformation.java
@@ -60,9 +60,6 @@ public class TraceCompletionInformation {
         this.communications = communications;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "TraceCompletionInformation [completionTime=" + completionTime + ", communications=" + communications
@@ -77,7 +74,6 @@ public class TraceCompletionInformation {
      */
     public static class Communication {
 
-        /**  */
         public static final int DEFAULT_EXPIRY_WINDOW = 4000;
 
         private List<String> ids = new ArrayList<String>();
@@ -141,9 +137,6 @@ public class TraceCompletionInformation {
             this.expire = expire;
         }
 
-        /* (non-Javadoc)
-         * @see java.lang.Object#toString()
-         */
         @Override
         public String toString() {
             return "Communication [ids=" + ids + ", multipleConsumers=" + multipleConsumers + ", baseDuration="

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiator.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiator.java
@@ -46,9 +46,6 @@ public class TraceCompletionInformationInitiator extends
         super(ProcessorType.OneToOne);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.String,java.lang.Object)
-     */
     @Override
     public TraceCompletionInformation processOneToOne(String tenantId,
             Trace item) throws RetryAttemptException {

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationProcessor.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationProcessor.java
@@ -51,9 +51,6 @@ public class TraceCompletionInformationProcessor extends
         super(ProcessorType.OneToOne);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#getDeliveryDelay(java.util.List)
-     */
     @Override
     public long getDeliveryDelay(List<TraceCompletionInformation> results) {
         // TODO: Just return default 500msec delay for now, but when supporting long running
@@ -76,9 +73,6 @@ public class TraceCompletionInformationProcessor extends
         this.communicationDetailsCache = communicationDetailsCache;
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.String,java.lang.Object)
-     */
     @Override
     public TraceCompletionInformation processOneToOne(String tenantId,
             TraceCompletionInformation item) throws RetryAttemptException {

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionTimeDeriver.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionTimeDeriver.java
@@ -39,9 +39,6 @@ public class TraceCompletionTimeDeriver extends AbstractProcessor<TraceCompletio
         super(ProcessorType.OneToOne);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.task.Processor#processSingle(java.lang.String,java.lang.Object)
-     */
     @Override
     public CompletionTime processOneToOne(String tenantId, TraceCompletionInformation item)
             throws RetryAttemptException {

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriverTest.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriverTest.java
@@ -46,7 +46,6 @@ import org.junit.Test;
  */
 public class CommunicationDetailsDeriverTest {
 
-    /**  */
     private static final String BTXN_NAME = "traceName";
 
     @Test

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/TestSourceInfoCache.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/TestSourceInfoCache.java
@@ -30,17 +30,11 @@ public class TestSourceInfoCache implements SourceInfoCache {
 
     private Map<String,SourceInfo> sourceInfoCache = new HashMap<String,SourceInfo>();
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.communicationdetails.SourceInfoCache#get(java.lang.String, java.lang.String)
-     */
     @Override
     public SourceInfo get(String tenantId, String id) {
         return sourceInfoCache.get(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.communicationdetails.SourceInfoCache#store(java.lang.String, java.util.List)
-     */
     @Override
     public void store(String tenantId, List<SourceInfo> sourceInfoList) {
         for (int i=0; i < sourceInfoList.size(); i++) {

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/nodedetails/NodeDetailsDeriverTest.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/nodedetails/NodeDetailsDeriverTest.java
@@ -33,10 +33,8 @@ import org.junit.Test;
  */
 public class NodeDetailsDeriverTest {
 
-    /**  */
     private static final String INTERNAL_URI = "internalUri";
 
-    /**  */
     private static final String TEST_URI = "testUri";
 
     @Test

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/tracecompletiontime/TestCommunicationDetailsCache.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/tracecompletiontime/TestCommunicationDetailsCache.java
@@ -33,17 +33,11 @@ public class TestCommunicationDetailsCache implements CommunicationDetailsCache 
     private Map<String, List<CommunicationDetails>> multipleConsumers = new HashMap<String,
                             List<CommunicationDetails>>();
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.btxncompletiontime.CommunicationDetailsCache#getSingleConsumer(java.lang.String)
-     */
     @Override
     public CommunicationDetails get(String tenantId, String id) {
         return singleConsumer.get(id);
     }
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.processor.btxncompletiontime.CommunicationDetailsCache#store(java.util.List)
-     */
     @Override
     public void store(String tenantId, List<CommunicationDetails> details) {
         for (int i=0; i < details.size(); i++) {

--- a/server/security-jaas/src/main/java/org/hawkular/apm/server/security/jaas/JAASSecurityProvider.java
+++ b/server/security-jaas/src/main/java/org/hawkular/apm/server/security/jaas/JAASSecurityProvider.java
@@ -24,12 +24,8 @@ import org.hawkular.apm.server.api.security.SecurityProviderException;
  */
 public class JAASSecurityProvider implements SecurityProvider {
 
-    /**  */
     protected static final String DEFAULT_TENANT = "hawkular";
 
-    /* (non-Javadoc)
-     * @see org.hawkular.apm.server.api.security.SecurityProvider#validate(java.lang.String, java.lang.String)
-     */
     @Override
     public String validate(String tenant, String principal) throws SecurityProviderException {
         return tenant == null ? DEFAULT_TENANT : tenant;

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterAsyncITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterAsyncITest.java
@@ -287,7 +287,6 @@ public class ClientJettyReaderWriterAsyncITest extends ClientTestBase {
 
     public static class EmbeddedAsyncServlet extends HttpServlet {
 
-        /**  */
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterITest.java
@@ -285,7 +285,6 @@ public class ClientJettyReaderWriterITest extends ClientTestBase {
 
     public static class EmbeddedServlet extends HttpServlet {
 
-        /**  */
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamAsyncITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamAsyncITest.java
@@ -290,7 +290,6 @@ public class ClientJettyStreamAsyncITest extends ClientTestBase {
 
     public static class EmbeddedAsyncServlet extends HttpServlet {
 
-        /**  */
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamITest.java
@@ -388,7 +388,6 @@ public class ClientJettyStreamITest extends ClientTestBase {
 
     public static class EmbeddedServlet extends HttpServlet {
 
-        /**  */
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/camel/ClientCamelRestletITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/camel/ClientCamelRestletITest.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  */
 public class ClientCamelRestletITest extends ClientCamelITestBase {
 
-    /**  */
     private static final String ORDER_CREATED = "Order created";
 
     @Override

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/camel/ClientCamelVmSedaITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/camel/ClientCamelVmSedaITest.java
@@ -44,7 +44,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  */
 public class ClientCamelVmSedaITest extends ClientCamelITestBase {
 
-    /**  */
     private static final String ORDER_CREATED = "Order created";
 
     @Override


### PR DESCRIPTION
Used  regex:
* `\n.*/\*\*  \*/` 
* `\n.*/\* \(non-Javadoc\)(?s:(?!\*/).)*\*/`

@objectiser could you please review?