### PR TITLE
HWKAPM-669 Source endpoint information in communication details for '…

### DIFF
--- a/client/opentracing/src/main/java/io/opentracing/AbstractAPMTracer.java
+++ b/client/opentracing/src/main/java/io/opentracing/AbstractAPMTracer.java
@@ -35,21 +35,6 @@ public abstract class AbstractAPMTracer extends AbstractTracer {
 
     private static final Logger log = Logger.getLogger(APMTracer.class.getName());
 
-    /** This constant represents the prefix used by all Hawkular APM state. */
-    public static final String HAWKULAR_APM_PREFIX = "Hawkular-APM";
-
-    /** This constant represents the interaction id exchanges between a sender and receiver. */
-    public static final String HAWKULAR_APM_ID = HAWKULAR_APM_PREFIX + "-Id";
-
-    /** This constant represents the transaction name. */
-    public static final String HAWKULAR_BT_NAME = HAWKULAR_APM_PREFIX + "-BTxn";
-
-    /** This constant represents the reporting level. */
-    public static final String HAWKULAR_APM_LEVEL = HAWKULAR_APM_PREFIX + "-Level";
-
-    /** Tag name used to represent the business transaction name */
-    public static final String TRANSACTION_NAME = "transaction.name";
-
     private TraceReporter reporter;
 
     public AbstractAPMTracer() {
@@ -80,7 +65,7 @@ public abstract class AbstractAPMTracer extends AbstractTracer {
         if (spanContext instanceof APMSpan) {
             APMSpan span = (APMSpan) spanContext;
             if (span.getInteractionId() != null) {
-                ret.put(AbstractAPMTracer.HAWKULAR_APM_ID, span.getInteractionId());
+                ret.put(APMTracer.HAWKULAR_APM_ID, span.getInteractionId());
             } else {
                 // Not sure if issue - but just logging as warning for now
                 log.warning("No id available to include in trace state for context = " + spanContext);
@@ -90,17 +75,17 @@ public abstract class AbstractAPMTracer extends AbstractTracer {
             // has been defined in the span tags - if so copy the value to the trace
             // context so that it can be propagated to invoked services
             if (span.getTraceContext().getBusinessTransaction() == null
-                    && span.getTags().containsKey(TRANSACTION_NAME)) {
-                span.getTraceContext().setBusinessTransaction(span.getTags().get(TRANSACTION_NAME).toString());
+                    && span.getTags().containsKey(APMTracer.TRANSACTION_NAME)) {
+                span.getTraceContext().setBusinessTransaction(span.getTags().get(APMTracer.TRANSACTION_NAME).toString());
             }
 
             // If transaction name defined on trace context, then propagate it
             if (span.getTraceContext().getBusinessTransaction() != null) {
-                ret.put(AbstractAPMTracer.HAWKULAR_BT_NAME, span.getTraceContext().getBusinessTransaction());
+                ret.put(APMTracer.HAWKULAR_BT_NAME, span.getTraceContext().getBusinessTransaction());
             }
 
             if (span.getTraceContext().getReportingLevel() != null) {
-                ret.put(AbstractAPMTracer.HAWKULAR_APM_LEVEL, span.getTraceContext().getReportingLevel());
+                ret.put(APMTracer.HAWKULAR_APM_LEVEL, span.getTraceContext().getReportingLevel());
             }
         }
 

--- a/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/APMTracer.java
+++ b/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/APMTracer.java
@@ -30,6 +30,21 @@ import io.opentracing.AbstractAPMTracer;
 @Singleton
 public class APMTracer extends AbstractAPMTracer {
 
+    /** This constant represents the prefix used by all Hawkular APM state. */
+    public static final String HAWKULAR_APM_PREFIX = "Hawkular-APM";
+
+    /** This constant represents the interaction id exchanges between a sender and receiver. */
+    public static final String HAWKULAR_APM_ID = HAWKULAR_APM_PREFIX + "-Id";
+
+    /** This constant represents the transaction name. */
+    public static final String HAWKULAR_BT_NAME = HAWKULAR_APM_PREFIX + "-BTxn";
+
+    /** This constant represents the reporting level. */
+    public static final String HAWKULAR_APM_LEVEL = HAWKULAR_APM_PREFIX + "-Level";
+
+    /** Tag name used to represent the business transaction name */
+    public static final String TRANSACTION_NAME = "transaction.name";
+
     public APMTracer() {
     }
 

--- a/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/DefaultNodeProcessor.java
+++ b/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/DefaultNodeProcessor.java
@@ -16,8 +16,6 @@
  */
 package org.hawkular.apm.client.opentracing;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 
 import org.hawkular.apm.api.model.Property;
@@ -38,14 +36,9 @@ public class DefaultNodeProcessor implements NodeProcessor {
             if (entry.getKey() != null && entry.getValue() != null) {
                 nodeBuilder.addProperty(new Property(entry.getKey(), entry.getValue().toString()));
 
-                if (entry.getKey().endsWith(".url") || entry.getKey().endsWith(".uri")) {
-                    try {
-                        URL url = new URL(entry.getValue().toString());
-                        nodeBuilder.setUri(url.getPath());
-                    } catch (MalformedURLException e) {
-                        nodeBuilder.setUri(entry.getValue().toString());
-                    }
-                    String type=entry.getKey().substring(0, entry.getKey().length() - 4);
+                if (TagUtil.isUriKey(entry.getKey())) {
+                    nodeBuilder.setUri(TagUtil.getUriPath(entry.getValue().toString()));
+                    String type = TagUtil.getTypeFromUriKey(entry.getKey());
                     nodeBuilder.setEndpointType(type);
                     nodeBuilder.setComponentType(type);
                 } else if (entry.getKey().equals("component")) {

--- a/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/NodeBuilder.java
+++ b/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/NodeBuilder.java
@@ -44,7 +44,8 @@ public class NodeBuilder {
 
     private String uri;
     private String operation;
-    private String endpointType;
+    private String endpointType = "n/a";    // Default endpoint type used to signify an external endpoint but
+                                            // type is unknown. A 'null' endpoint is for internal connections.
     private String componentType;
     private String fault;
     private long duration;
@@ -232,4 +233,5 @@ public class NodeBuilder {
 
         return ret;
     }
+
 }

--- a/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/TagUtil.java
+++ b/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/TagUtil.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.apm.client.opentracing;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * This class provides utility functions for processing tags.
+ *
+ * @author gbrown
+ */
+public class TagUtil {
+
+    /**
+     * This method determines if the supplied key relates to
+     * a URI.
+     *
+     * @param key The key
+     * @return Whether the key relates to a URI
+     */
+    public static boolean isUriKey(String key) {
+        return key.endsWith(".url") || key.endsWith(".uri");
+    }
+
+    /**
+     * This method extracts a 'type' from the key used
+     * to identify the URI. This assumes that the key structure
+     * is '<type>.uri' or '<type>.url'.
+     *
+     * @param key The key
+     * @return The type
+     */
+    public static String getTypeFromUriKey(String key) {
+        return key.substring(0, key.length() - 4);
+    }
+
+    /**
+     * This method extracts the 'path' component of a
+     * URL. If the supplied value is not a valid URL
+     * format, then it will simply return the supplied
+     * value.
+     *
+     * @param value The URI value
+     * @return The path of a URL, or the value returned as is
+     */
+    public static String getUriPath(String value) {
+        try {
+            URL url = new URL(value);
+            return url.getPath();
+        } catch (MalformedURLException e) {
+            return value;
+        }
+    }
+
+    /**
+     * This method returns the URI value from a set of
+     * supplied tags, by first identifying which tag
+     * relates to a URI and then returning its path value.
+     *
+     * @param tags The tags
+     * @return The URI path, or null if not found
+     */
+    public static String getUriPath(Map<String, Object> tags) {
+        for (Map.Entry<String,Object> entry : tags.entrySet()) {
+            if (isUriKey(entry.getKey())) {
+                return getUriPath(entry.getValue().toString());
+            }
+        }
+        return null;
+    }
+
+}

--- a/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/TraceContext.java
+++ b/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/TraceContext.java
@@ -21,10 +21,13 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.hawkular.apm.api.model.events.EndpointRef;
 import org.hawkular.apm.api.model.trace.Node;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.utils.PropertyUtil;
 import org.hawkular.apm.client.api.reporter.TraceReporter;
+
+import io.opentracing.APMSpan;
 
 /**
  * This class represents the context associated with a trace instance.
@@ -34,6 +37,8 @@ import org.hawkular.apm.client.api.reporter.TraceReporter;
 public class TraceContext {
 
     private Trace trace;
+
+    private APMSpan topSpan;
 
     private NodeBuilder rootNode;
 
@@ -58,7 +63,8 @@ public class TraceContext {
      * @param startTime The start time for the trace fragment (in milliseconds)
      * @param reporter The trace reporter
      */
-    public TraceContext(NodeBuilder rootNode, long startTime, TraceReporter reporter) {
+    public TraceContext(APMSpan topSpan, NodeBuilder rootNode, long startTime, TraceReporter reporter) {
+        this.topSpan = topSpan;
         this.rootNode = rootNode;
         this.reporter = reporter;
 
@@ -131,6 +137,26 @@ public class TraceContext {
      */
     public List<NodeProcessor> getNodeProcessors() {
         return nodeProcessors;
+    }
+
+    /**
+     * This method returns the top span associated with the traces involved in the current
+     * service invocation.
+     *
+     * @return The top span
+     */
+    public APMSpan getTopSpan() {
+        return topSpan;
+    }
+
+    /**
+     * This method returns the source endpoint for the root trace fragment generated
+     * by the service invocation.
+     *
+     * @return The source endpoint
+     */
+    public EndpointRef getSourceEndpoint() {
+        return new EndpointRef(TagUtil.getUriPath(topSpan.getTags()), topSpan.getOperationName(), false);
     }
 
 }

--- a/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/APMTracerTest.java
+++ b/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/APMTracerTest.java
@@ -33,6 +33,7 @@ import org.hawkular.apm.api.model.trace.CorrelationIdentifier;
 import org.hawkular.apm.api.model.trace.CorrelationIdentifier.Scope;
 import org.hawkular.apm.api.model.trace.Producer;
 import org.hawkular.apm.api.model.trace.Trace;
+import org.hawkular.apm.api.utils.EndpointUtil;
 import org.hawkular.apm.client.api.reporter.TraceReporter;
 import org.hawkular.apm.tests.common.Wait;
 import org.junit.BeforeClass;
@@ -350,12 +351,18 @@ public class APMTracerTest {
         Trace trace2 = reporter.getTraces().get(1);
         assertEquals(TEST_BTXN, trace2.getBusinessTransaction());
         assertEquals(1, trace2.getNodes().size());
-        assertEquals(Component.class, trace2.getNodes().get(0).getClass());
+        assertEquals(Consumer.class, trace2.getNodes().get(0).getClass());
 
-        Component component2 = (Component) trace2.getNodes().get(0);
+        Consumer consumer2 = (Consumer) trace2.getNodes().get(0);
 
-        assertTrue(component2.getCorrelationIds().contains(new CorrelationIdentifier(Scope.CausedBy,
+        assertTrue(consumer2.getCorrelationIds().contains(new CorrelationIdentifier(Scope.CausedBy,
                 trace1.getId() + ":0:0")));
+        assertEquals(EndpointUtil.getSourceEndpoint(trace1), EndpointUtil.getSourceEndpoint(trace2));
+
+        assertEquals(1, consumer2.getNodes().size());
+        assertEquals(Component.class, consumer2.getNodes().get(0).getClass());
+
+        Component component2 = (Component) consumer2.getNodes().get(0);
 
         // Get producer invoking a remote service
         assertEquals(1, component2.getNodes().size());


### PR DESCRIPTION
…follows from' fragment was not correct - needs to match the top level fragment within the invoked service, so that dependencies from that service can correctly be derived.

Set endpoint to a default value, as a null endpointType is used to signify 'spawned' concurrent fragment link. Stored the node path, as the node builders are cleared after the trace is built