### PR TITLE
HWKAPM-675 Removed fault field from node and derived events, in favou…

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandler.java
+++ b/api/src/main/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandler.java
@@ -18,6 +18,8 @@ package org.hawkular.apm.api.internal.actions;
 
 import java.util.Map;
 
+import org.hawkular.apm.api.model.Constants;
+import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.config.Direction;
 import org.hawkular.apm.api.model.config.btxn.ProcessorAction;
 import org.hawkular.apm.api.model.trace.Node;
@@ -45,7 +47,7 @@ public class SetFaultActionHandler extends ExpressionBasedActionHandler {
         if (super.process(trace, node, direction, headers, values)) {
             String value = getValue(trace, node, direction, headers, values);
             if (value != null) {
-                node.setFault(value);
+                node.getProperties().add(new Property(Constants.PROP_FAULT, value));
                 return true;
             }
         }

--- a/api/src/main/java/org/hawkular/apm/api/model/Constants.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/Constants.java
@@ -48,6 +48,12 @@ public class Constants {
     public static final String PROP_TRANSACTION_NAME = "transaction";
 
     /**
+     * Property key representing the fault
+     * {@link org.hawkular.apm.api.model.Property#name}
+     */
+    public static final String PROP_FAULT = "fault";
+
+    /**
      * Details key representing a description of a fault.
      */
     public static final String DETAIL_FAULT_DESCRIPTION = "fault.description";

--- a/api/src/main/java/org/hawkular/apm/api/model/events/CompletionTime.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/events/CompletionTime.java
@@ -56,9 +56,6 @@ public class CompletionTime implements ApmEvent {
     private String principal;
 
     @JsonInclude(Include.NON_NULL)
-    private String fault;
-
-    @JsonInclude(Include.NON_NULL)
     private String hostName;
 
     @JsonInclude(Include.NON_NULL)
@@ -186,20 +183,6 @@ public class CompletionTime implements ApmEvent {
     }
 
     /**
-     * @return the fault
-     */
-    public String getFault() {
-        return fault;
-    }
-
-    /**
-     * @param fault the fault to set
-     */
-    public void setFault(String fault) {
-        this.fault = fault;
-    }
-
-    /**
      * This method sets the hostname, where the completion time is associated
      * with a fragment.
      *
@@ -299,7 +282,7 @@ public class CompletionTime implements ApmEvent {
     public String toString() {
         return "CompletionTime [id=" + id + ", uri=" + uri + ", operation=" + operation + ", endpointType="
                 + endpointType + ", businessTransaction=" + businessTransaction + ", timestamp=" + timestamp
-                + ", duration=" + duration + ", principal=" + principal + ", fault=" + fault + ", hostName="
+                + ", duration=" + duration + ", principal=" + principal + ", hostName="
                 + hostName + ", properties=" + properties + ", internal=" + internal + "]";
     }
 

--- a/api/src/main/java/org/hawkular/apm/api/model/events/NodeDetails.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/events/NodeDetails.java
@@ -66,9 +66,6 @@ public class NodeDetails implements ApmEvent {
     private String operation;
 
     @JsonInclude(Include.NON_NULL)
-    private String fault;
-
-    @JsonInclude(Include.NON_NULL)
     private String hostName;
 
     @JsonInclude(Include.NON_NULL)
@@ -218,20 +215,6 @@ public class NodeDetails implements ApmEvent {
     }
 
     /**
-     * @return the fault
-     */
-    public String getFault() {
-        return fault;
-    }
-
-    /**
-     * @param fault the fault to set
-     */
-    public void setFault(String fault) {
-        this.fault = fault;
-    }
-
-    /**
      * @return the hostName
      */
     public String getHostName() {
@@ -362,7 +345,6 @@ public class NodeDetails implements ApmEvent {
         result = prime * result + ((correlationIds == null) ? 0 : correlationIds.hashCode());
         result = prime * result + ((details == null) ? 0 : details.hashCode());
         result = prime * result + (int) (elapsed ^ (elapsed >>> 32));
-        result = prime * result + ((fault == null) ? 0 : fault.hashCode());
         result = prime * result + ((hostName == null) ? 0 : hostName.hashCode());
         result = prime * result + ((id == null) ? 0 : id.hashCode());
         result = prime * result + ((operation == null) ? 0 : operation.hashCode());
@@ -407,11 +389,6 @@ public class NodeDetails implements ApmEvent {
             return false;
         if (elapsed != other.elapsed)
             return false;
-        if (fault == null) {
-            if (other.fault != null)
-                return false;
-        } else if (!fault.equals(other.fault))
-            return false;
         if (hostName == null) {
             if (other.hostName != null)
                 return false;
@@ -453,7 +430,7 @@ public class NodeDetails implements ApmEvent {
     public String toString() {
         return "NodeDetails [id=" + id + ", businessTransaction=" + businessTransaction + ", type=" + type + ", uri="
                 + uri + ", timestamp=" + timestamp + ", elapsed=" + elapsed + ", actual=" + actual + ", componentType="
-                + componentType + ", operation=" + operation + ", fault=" + fault + ", hostName=" + hostName
+                + componentType + ", operation=" + operation + ", hostName=" + hostName
                 + ", principal=" + principal + ", properties=" + properties + ", details=" + details
                 + ", correlationIds=" + correlationIds + "]";
     }

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Component.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Component.java
@@ -93,7 +93,7 @@ public class Component extends InteractionNode {
         return "Component [componentType=" + componentType + ", getIn()=" + getIn() + ", getOut()=" + getOut()
                 + ", getNodes()=" + getNodes() + ", getType()=" + getType() + ", getUri()=" + getUri()
                 + ", getOperation()=" + getOperation() + ", getBaseTime()=" + getBaseTime() + ", getDuration()="
-                + getDuration() + ", getFault()=" + getFault() + ", getProperties()=" + getProperties()
+                + getDuration() + ", getProperties()=" + getProperties()
                 + ", getDetails()=" + getDetails() + ", getCorrelationIds()=" + getCorrelationIds() + ", getIssues()="
                 + getIssues() + "]";
     }

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Consumer.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Consumer.java
@@ -94,7 +94,7 @@ public class Consumer extends InteractionNode {
         return "Consumer [endpointType=" + endpointType + ", getIn()=" + getIn() + ", getOut()=" + getOut()
                 + ", getNodes()=" + getNodes() + ", getType()=" + getType() + ", getUri()=" + getUri()
                 + ", getOperation()=" + getOperation() + ", getBaseTime()=" + getBaseTime() + ", getDuration()="
-                + getDuration() + ", getFault()=" + getFault() + ", getProperties()=" + getProperties()
+                + getDuration() + ", getProperties()=" + getProperties()
                 + ", getDetails()=" + getDetails() + ", getCorrelationIds()=" + getCorrelationIds() + ", getIssues()="
                 + getIssues() + "]";
     }

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Node.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Node.java
@@ -63,9 +63,6 @@ public abstract class Node {
     @JsonInclude
     private long duration = 0;
 
-    @JsonInclude(Include.NON_NULL)
-    private String fault;
-
     @JsonInclude(Include.NON_EMPTY)
     private Set<Property> properties = new HashSet<Property>();
 
@@ -180,22 +177,6 @@ public abstract class Node {
      */
     public Node setDuration(long duration) {
         this.duration = duration;
-        return this;
-    }
-
-    /**
-     * @return the fault
-     */
-    public String getFault() {
-        return fault;
-    }
-
-    /**
-     * @param fault the fault to set
-     * @return The node
-     */
-    public Node setFault(String fault) {
-        this.fault = fault;
         return this;
     }
 
@@ -445,7 +426,6 @@ public abstract class Node {
         result = prime * result + ((correlationIds == null) ? 0 : correlationIds.hashCode());
         result = prime * result + ((details == null) ? 0 : details.hashCode());
         result = prime * result + (int) (duration ^ (duration >>> 32));
-        result = prime * result + ((fault == null) ? 0 : fault.hashCode());
         result = prime * result + ((issues == null) ? 0 : issues.hashCode());
         result = prime * result + ((operation == null) ? 0 : operation.hashCode());
         result = prime * result + ((properties == null) ? 0 : properties.hashCode());
@@ -476,11 +456,6 @@ public abstract class Node {
         } else if (!details.equals(other.details))
             return false;
         if (duration != other.duration)
-            return false;
-        if (fault == null) {
-            if (other.fault != null)
-                return false;
-        } else if (!fault.equals(other.fault))
             return false;
         if (issues == null) {
             if (other.issues != null)

--- a/api/src/main/java/org/hawkular/apm/api/model/trace/Producer.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/trace/Producer.java
@@ -94,7 +94,7 @@ public class Producer extends InteractionNode {
         return "Producer [endpointType=" + endpointType + ", getIn()=" + getIn() + ", getOut()=" + getOut()
                 + ", getNodes()=" + getNodes() + ", getType()=" + getType() + ", getUri()=" + getUri()
                 + ", getOperation()=" + getOperation() + ", getBaseTime()=" + getBaseTime() + ", getDuration()="
-                + getDuration() + ", getFault()=" + getFault() + ", getProperties()=" + getProperties()
+                + getDuration() + ", getProperties()=" + getProperties()
                 + ", getDetails()=" + getDetails() + ", getCorrelationIds()=" + getCorrelationIds() + ", getIssues()="
                 + getIssues() + "]";
     }

--- a/api/src/main/java/org/hawkular/apm/api/services/AbstractAnalyticsService.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/AbstractAnalyticsService.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.analytics.CommunicationSummaryStatistics;
 import org.hawkular.apm.api.model.analytics.CommunicationSummaryStatistics.ConnectionStatistics;
 import org.hawkular.apm.api.model.analytics.EndpointInfo;
@@ -385,7 +386,7 @@ public abstract class AbstractAnalyticsService implements AnalyticsService {
                     // Check whether endpoint already known, and that it did not result
                     // in a fault (e.g. want to ignore spurious URIs that are not
                     // associated with a valid transaction)
-                    if (!map.containsKey(endpoint) && consumer.getFault() == null) {
+                    if (!map.containsKey(endpoint) && consumer.getProperties(Constants.PROP_FAULT).isEmpty()) {
                         EndpointInfo info = new EndpointInfo();
                         info.setEndpoint(endpoint);
                         info.setType(consumer.getEndpointType());

--- a/api/src/main/java/org/hawkular/apm/api/services/Criteria.java
+++ b/api/src/main/java/org/hawkular/apm/api/services/Criteria.java
@@ -39,7 +39,6 @@ public class Criteria {
     private String businessTransaction;
     private Set<PropertyCriteria> properties = new HashSet<PropertyCriteria>();
     private Set<CorrelationIdentifier> correlationIds = new HashSet<CorrelationIdentifier>();
-    private Set<FaultCriteria> faults = new HashSet<FaultCriteria>();
     private String hostName;
     private long upperBound;
     private long lowerBound;
@@ -79,7 +78,6 @@ public class Criteria {
 
         criteria.properties.forEach(pc -> this.properties.add(new PropertyCriteria(pc)));
         criteria.correlationIds.forEach(cid -> this.correlationIds.add(new CorrelationIdentifier(cid)));
-        criteria.faults.forEach(fc -> this.faults.add(new FaultCriteria(fc)));
     }
 
     /**
@@ -307,22 +305,6 @@ public class Criteria {
     }
 
     /**
-     * @return the faults
-     */
-    public Set<FaultCriteria> getFaults() {
-        return faults;
-    }
-
-    /**
-     * @param fault the fault to set
-     * @return The criteria
-     */
-    public Criteria setFaults(Set<FaultCriteria> faults) {
-        this.faults = faults;
-        return this;
-    }
-
-    /**
      * @return the timeout
      */
     public long getTimeout() {
@@ -411,23 +393,6 @@ public class Criteria {
             ret.put("correlations", buf.toString());
         }
 
-        // Only relevant for completion time queries
-        if (!getFaults().isEmpty()) {
-            boolean first = true;
-            StringBuilder buf = new StringBuilder();
-
-            for (FaultCriteria pc : getFaults()) {
-                if (first) {
-                    first = false;
-                } else {
-                    buf.append(',');
-                }
-                buf.append(pc.encoded());
-            }
-
-            ret.put("faults", buf.toString());
-        }
-
         if (principal != null) {
             ret.put("principal", principal);
         }
@@ -454,7 +419,7 @@ public class Criteria {
      * @return Whether the criteria would apply to all fragments in a transaction
      */
     public boolean transactionWide() {
-        return !(!properties.isEmpty() || !correlationIds.isEmpty() || !faults.isEmpty() || hostName != null
+        return !(!properties.isEmpty() || !correlationIds.isEmpty() || hostName != null
                 || uri != null || operation != null);
     }
 
@@ -476,7 +441,7 @@ public class Criteria {
     public String toString() {
         return "Criteria [startTime=" + startTime + ", endTime=" + endTime + ", businessTransaction="
                 + businessTransaction + ", properties=" + properties + ", correlationIds=" + correlationIds
-                + ", faults=" + faults + ", hostName=" + hostName + ", upperBound=" + upperBound + ", lowerBound="
+                + ", hostName=" + hostName + ", upperBound=" + upperBound + ", lowerBound="
                 + lowerBound + ", principal=" + principal + ", uri=" + uri + ", operation=" + operation + ", timeout="
                 + timeout + ", maxResponseSize=" + maxResponseSize + "]";
     }
@@ -623,92 +588,4 @@ public class Criteria {
 
     }
 
-    /**
-     * This class represents the fault criteria.
-     */
-    public static class FaultCriteria {
-
-        private String value;
-
-        private Operator operator = Operator.HAS;
-
-        /**
-         * This is the default constructor.
-         */
-        public FaultCriteria() {
-        }
-
-        /**
-         * This is the copy constructor.
-         *
-         * @param fc The fault criteria
-         */
-        public FaultCriteria(FaultCriteria fc) {
-            this.value = fc.value;
-            this.operator = fc.operator;
-        }
-
-        /**
-         * This constructor initialises the fields.
-         *
-         * @param value The value
-         * @param operator The comparison operator
-         */
-        public FaultCriteria(String value, Operator operator) {
-            this.value = value;
-            setOperator(operator);
-        }
-
-        /**
-         * @return the value
-         */
-        public String getValue() {
-            return value;
-        }
-
-        /**
-         * @param value the value to set
-         */
-        public void setValue(String value) {
-            this.value = value;
-        }
-
-        /**
-         * @return the operator
-         */
-        public Operator getOperator() {
-            return operator;
-        }
-
-        /**
-         * @param operator the operator to set
-         */
-        public void setOperator(Operator operator) {
-            if (operator == null) {
-                operator = Operator.HAS;
-            }
-            this.operator = operator;
-        }
-
-        /**
-         * This method returns an encoded form for the
-         * property criteria.
-         *
-         * @return The encoded form
-         */
-        public String encoded() {
-            StringBuilder buf = new StringBuilder();
-            buf.append(getValue());
-            if (getOperator() != Operator.HAS) {
-                buf.append('|');
-                buf.append(getOperator());
-            }
-            return buf.toString();
-        }
-
-        @Override
-        public String toString() {
-            return "FaultCriteria [value=" + value + ", operator=" + operator + "]";
-        }
-    }
 }

--- a/api/src/test/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandlerTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/internal/actions/SetFaultActionHandlerTest.java
@@ -19,6 +19,7 @@ package org.hawkular.apm.api.internal.actions;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.config.Direction;
 import org.hawkular.apm.api.model.config.btxn.LiteralExpression;
 import org.hawkular.apm.api.model.config.btxn.SetFaultAction;
@@ -45,7 +46,8 @@ public class SetFaultActionHandlerTest {
 
         handler.process(null, node, Direction.In, null, null);
 
-        assertEquals(TEST_VALUE_1, node.getFault());
+        assertEquals(1, node.getProperties(Constants.PROP_FAULT).size());
+        assertEquals(TEST_VALUE_1, node.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
 
         assertNull(handler.getIssues());
     }

--- a/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollector.java
+++ b/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollector.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.hawkular.apm.api.logging.Logger;
 import org.hawkular.apm.api.logging.Logger.Level;
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.config.CollectorConfiguration;
 import org.hawkular.apm.api.model.config.Direction;
@@ -766,7 +767,7 @@ public class DefaultTraceCollector implements TraceCollector, SessionManager {
             if (fragmentManager.hasFragmentBuilder()) {
                 FragmentBuilder builder = fragmentManager.getFragmentBuilder();
 
-                builder.getCurrentNode().setFault(value);
+                builder.getCurrentNode().getProperties().add(new Property(Constants.PROP_FAULT, value));
             } else if (log.isLoggable(warningLogLevel)) {
                 log.log(warningLogLevel, "setFault: No fragment builder for this thread", null);
             }

--- a/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/ProcessorManager.java
+++ b/client/collector/src/main/java/org/hawkular/apm/client/collector/internal/ProcessorManager.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -29,6 +30,8 @@ import org.hawkular.apm.api.internal.actions.ProcessorActionHandler;
 import org.hawkular.apm.api.internal.actions.ProcessorActionHandlerFactory;
 import org.hawkular.apm.api.logging.Logger;
 import org.hawkular.apm.api.logging.Logger.Level;
+import org.hawkular.apm.api.model.Constants;
+import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.Severity;
 import org.hawkular.apm.api.model.config.CollectorConfiguration;
 import org.hawkular.apm.api.model.config.Direction;
@@ -420,15 +423,17 @@ public class ProcessorManager {
                     return;
                 }
 
+                Set<Property> faults = node.getProperties(Constants.PROP_FAULT);
+
                 // If fault filter not defined, then node cannot have a fault
-                if (faultFilter == null && node.getFault() != null) {
+                if (faultFilter == null &&  !faults.isEmpty()) {
                     return;
                 }
 
                 // If fault filter regex expression defined, then verify whether
                 // node fault string matches.
-                if (faultFilter != null && (node.getFault() == null
-                        || !faultFilter.test(node.getFault()))) {
+                if (faultFilter != null &&
+                        faults.stream().filter(f -> faultFilter.test(f.getValue())).count() == 0) {
                     return;
                 }
 

--- a/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/ProcessorManagerTest.java
+++ b/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/ProcessorManagerTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hawkular.apm.api.model.Constants;
+import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.config.CollectorConfiguration;
 import org.hawkular.apm.api.model.config.Direction;
 import org.hawkular.apm.api.model.config.btxn.AddContentAction;
@@ -364,7 +366,8 @@ public class ProcessorManagerTest {
 
         pm.process(trace, service, Direction.In, null, "first", "second");
 
-        assertEquals("second", service.getFault());
+        assertEquals(1, service.getProperties(Constants.PROP_FAULT).size());
+        assertEquals("second", service.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
     }
 
     @Test
@@ -550,7 +553,7 @@ public class ProcessorManagerTest {
 
         Trace trace = new Trace();
         Consumer service = new Consumer();
-        service.setFault("NotSameFault");
+        service.getProperties().add(new Property(Constants.PROP_FAULT, "NotSameFault"));
 
         trace.getNodes().add(service);
         trace.setBusinessTransaction("testapp");
@@ -560,7 +563,8 @@ public class ProcessorManagerTest {
 
         pm.process(trace, service, Direction.In, null, "first", "second");
 
-        assertEquals(0, trace.allProperties().size());
+        // The 'fault' property
+        assertEquals(1, trace.allProperties().size());
     }
 
     @Test
@@ -589,7 +593,7 @@ public class ProcessorManagerTest {
 
         Trace trace = new Trace();
         Consumer service = new Consumer();
-        service.setFault("MyFault");
+        service.getProperties().add(new Property(Constants.PROP_FAULT, "MyFault"));
 
         trace.getNodes().add(service);
         trace.setBusinessTransaction("testapp");
@@ -599,7 +603,8 @@ public class ProcessorManagerTest {
 
         pm.process(trace, service, Direction.In, null, "first", "second");
 
-        assertEquals(1, trace.allProperties().size());
+        // Including the 'fault' property
+        assertEquals(2, trace.allProperties().size());
         assertTrue(trace.hasProperty("result"));
     }
 

--- a/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/DefaultNodeProcessor.java
+++ b/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/DefaultNodeProcessor.java
@@ -43,8 +43,6 @@ public class DefaultNodeProcessor implements NodeProcessor {
                     nodeBuilder.setComponentType(type);
                 } else if (entry.getKey().equals("component")) {
                     nodeBuilder.setComponentType(entry.getValue().toString());
-                } else if (entry.getKey().equals("fault")) {
-                    nodeBuilder.setFault(entry.getValue().toString());
                 } else if (entry.getKey().contains(Constants.PROP_TRANSACTION_NAME)) {
                     // Check if business transaction name already defined - if not then set on the trace context
                     if (context.getBusinessTransaction() == null) {

--- a/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/NodeBuilder.java
+++ b/client/opentracing/src/main/java/org/hawkular/apm/client/opentracing/NodeBuilder.java
@@ -47,7 +47,6 @@ public class NodeBuilder {
     private String endpointType = "n/a";    // Default endpoint type used to signify an external endpoint but
                                             // type is unknown. A 'null' endpoint is for internal connections.
     private String componentType;
-    private String fault;
     private long duration;
     private Set<Property> properties = new HashSet<>();
     private Map<String, String> details = new HashMap<>();
@@ -145,15 +144,6 @@ public class NodeBuilder {
     }
 
     /**
-     * @param fault the fault to set
-     * @return The node builder
-     */
-    public NodeBuilder setFault(String fault) {
-        this.fault = fault;
-        return this;
-    }
-
-    /**
      * @param duration The duration (in nanoseconds)
      * @return The node builder
      */
@@ -220,7 +210,6 @@ public class NodeBuilder {
         }
         ret.setCorrelationIds(correlationIds);
         ret.setDetails(details);
-        ret.setFault(fault);
         ret.setOperation(operation);
         ret.setProperties(properties);
         ret.setUri(uri);

--- a/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/APMTracerTest.java
+++ b/client/opentracing/src/test/java/org/hawkular/apm/client/opentracing/APMTracerTest.java
@@ -166,7 +166,8 @@ public class APMTracerTest {
         assertTrue(consumer.getCorrelationIds().contains(new CorrelationIdentifier(Scope.Interaction, TEST_APM_ID)));
 
         assertEquals("http", consumer.getEndpointType());
-        assertEquals(SyncService.MY_FAULT, consumer.getFault());
+        assertEquals(1, consumer.getProperties(Constants.PROP_FAULT).size());
+        assertEquals(SyncService.MY_FAULT, consumer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
 
         // Get middle component
         assertEquals(1, consumer.getNodes().size());
@@ -221,7 +222,8 @@ public class APMTracerTest {
         assertTrue(consumer.getCorrelationIds().contains(new CorrelationIdentifier(Scope.Interaction, TEST_APM_ID)));
 
         assertEquals("http", consumer.getEndpointType());
-        assertEquals(SyncService.MY_FAULT, consumer.getFault());
+        assertEquals(1, consumer.getProperties(Constants.PROP_FAULT).size());
+        assertEquals(SyncService.MY_FAULT, consumer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
 
         // Get middle component
         assertEquals(1, consumer.getNodes().size());
@@ -280,7 +282,8 @@ public class APMTracerTest {
         assertTrue(consumer.getCorrelationIds().contains(new CorrelationIdentifier(Scope.Interaction, TEST_APM_ID)));
 
         assertEquals("http", consumer.getEndpointType());
-        assertEquals(SyncService.MY_FAULT, consumer.getFault());
+        assertEquals(1, consumer.getProperties(Constants.PROP_FAULT).size());
+        assertEquals(SyncService.MY_FAULT, consumer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
 
         // Get middle component
         assertEquals(1, consumer.getNodes().size());

--- a/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchUtil.java
+++ b/server/elasticsearch/src/main/java/org/hawkular/apm/server/elasticsearch/ElasticsearchUtil.java
@@ -25,7 +25,6 @@ import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.api.model.events.NodeDetails;
 import org.hawkular.apm.api.model.trace.CorrelationIdentifier;
 import org.hawkular.apm.api.services.Criteria;
-import org.hawkular.apm.api.services.Criteria.FaultCriteria;
 import org.hawkular.apm.api.services.Criteria.Operator;
 import org.hawkular.apm.api.services.Criteria.PropertyCriteria;
 
@@ -113,16 +112,6 @@ public class ElasticsearchUtil {
                                 .must(QueryBuilders.matchQuery("correlationIds.scope", id.getScope()))
                                 .must(QueryBuilders.matchQuery("correlationIds.value", id.getValue()))));
                  */
-            }
-        }
-
-        if (!criteria.getFaults().isEmpty()) {
-            for (FaultCriteria fc : criteria.getFaults()) {
-                if (fc.getOperator() == Operator.HASNOT) {
-                    query = query.mustNot(QueryBuilders.matchQuery("fault", fc.getValue()));
-                } else {
-                    query = query.must(QueryBuilders.matchQuery("fault", fc.getValue()));
-                }
             }
         }
 

--- a/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearchTest.java
+++ b/server/elasticsearch/src/test/java/org/hawkular/apm/server/elasticsearch/AnalyticsServiceElasticsearchTest.java
@@ -57,7 +57,6 @@ import org.hawkular.apm.api.model.trace.Producer;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.services.ConfigurationService;
 import org.hawkular.apm.api.services.Criteria;
-import org.hawkular.apm.api.services.Criteria.FaultCriteria;
 import org.hawkular.apm.api.services.Criteria.Operator;
 import org.hawkular.apm.api.services.StoreException;
 import org.hawkular.apm.api.utils.EndpointUtil;
@@ -549,14 +548,14 @@ public class AnalyticsServiceElasticsearchTest {
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2000);
         ct2.setPrincipal("p2");
-        ct2.setFault("TestFault1");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault1"));
         ct2.setUri("uri2");
 
         CompletionTime ct3 = new CompletionTime();
         ct3.setBusinessTransaction(BTXN);
         ct3.setTimestamp(2000);
         ct3.setPrincipal("p1");
-        ct3.setFault("TestFault2");
+        ct3.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault2"));
         ct3.setUri("uri1");
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1, ct2, ct3));
@@ -582,14 +581,14 @@ public class AnalyticsServiceElasticsearchTest {
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2000);
         ct2.setPrincipal("p2");
-        ct2.setFault("TestFault1");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault1"));
         ct2.setUri("uri2");
 
         CompletionTime ct3 = new CompletionTime();
         ct3.setBusinessTransaction(BTXN);
         ct3.setTimestamp(2000);
         ct3.setPrincipal("p1");
-        ct3.setFault("TestFault2");
+        ct3.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault2"));
         ct3.setUri("uri1");
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1, ct2, ct3));
@@ -615,14 +614,14 @@ public class AnalyticsServiceElasticsearchTest {
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2000);
         ct2.setPrincipal("p2");
-        ct2.setFault("TestFault1");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault1"));
         ct2.setOperation(OP2);
 
         CompletionTime ct3 = new CompletionTime();
         ct3.setBusinessTransaction(BTXN);
         ct3.setTimestamp(2000);
         ct3.setPrincipal("p1");
-        ct3.setFault("TestFault2");
+        ct3.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault2"));
         ct3.setOperation(OP1);
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1, ct2, ct3));
@@ -683,12 +682,12 @@ public class AnalyticsServiceElasticsearchTest {
         CompletionTime ct2 = new CompletionTime();
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2000);
-        ct2.setFault("TestFault");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault"));
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1, ct2));
 
         Criteria criteria = new Criteria();
-        criteria.getFaults().add(new FaultCriteria("TestFault", null));
+        criteria.addProperty(Constants.PROP_FAULT, "TestFault", Criteria.Operator.HAS);
         criteria.setBusinessTransaction(BTXN).setStartTime(100).setEndTime(0);
 
         Wait.until(() -> analytics.getTraceCompletionCount(null, criteria) == 1);
@@ -704,17 +703,17 @@ public class AnalyticsServiceElasticsearchTest {
         CompletionTime ct2 = new CompletionTime();
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2000);
-        ct2.setFault("TestFault1");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault1"));
 
         CompletionTime ct3 = new CompletionTime();
         ct3.setBusinessTransaction(BTXN);
         ct3.setTimestamp(2000);
-        ct3.setFault("TestFault2");
+        ct3.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault2"));
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1, ct2, ct3));
 
         Criteria criteria = new Criteria();
-        criteria.getFaults().add(new FaultCriteria("TestFault1", Operator.HASNOT));
+        criteria.addProperty(Constants.PROP_FAULT, "TestFault1", Operator.HASNOT);
         criteria.setBusinessTransaction(BTXN).setStartTime(100).setEndTime(0);
 
         Wait.until(() -> analytics.getTraceCompletionCount(null, criteria) == 2);
@@ -732,13 +731,13 @@ public class AnalyticsServiceElasticsearchTest {
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2000);
         ct2.setPrincipal("p2");
-        ct2.setFault("TestFault1");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault1"));
 
         CompletionTime ct3 = new CompletionTime();
         ct3.setBusinessTransaction(BTXN);
         ct3.setTimestamp(2000);
         ct3.setPrincipal("p1");
-        ct3.setFault("TestFault2");
+        ct3.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault2"));
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1, ct2, ct3));
 
@@ -809,7 +808,7 @@ public class AnalyticsServiceElasticsearchTest {
         CompletionTime ct1 = new CompletionTime();
         ct1.setBusinessTransaction(BTXN);
         ct1.setTimestamp(1000);
-        ct1.setFault("Failed");
+        ct1.getProperties().add(new Property(Constants.PROP_FAULT, "Failed"));
 
         CompletionTime ct2 = new CompletionTime();
         ct2.setBusinessTransaction(BTXN);
@@ -979,7 +978,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setBusinessTransaction(BTXN);
         ct1_1.setTimestamp(1500);
         ct1_1.setDuration(100);
-        ct1_1.setFault("fault1");
+        ct1_1.getProperties().add(new Property(Constants.PROP_FAULT, "fault1"));
 
         CompletionTime ct1_2 = new CompletionTime();
         ct1_2.setBusinessTransaction(BTXN);
@@ -990,7 +989,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2100);
         ct2.setDuration(500);
-        ct2.setFault("fault2");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "fault2"));
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1_1, ct1_2, ct2));
 
@@ -1037,7 +1036,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setTimestamp(1600);
         ct1_2.setDuration(300);
         ct1_2.setPrincipal("p1");
-        ct1_2.setFault("fault1");
+        ct1_2.getProperties().add(new Property(Constants.PROP_FAULT, "fault1"));
 
         CompletionTime ct2 = new CompletionTime();
         ct2.setBusinessTransaction(BTXN);
@@ -1135,13 +1134,13 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setBusinessTransaction(BTXN);
         ct1_2.setTimestamp(1600);
         ct1_2.setDuration(300);
-        ct1_2.setFault("TestFault");
+        ct1_2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault"));
         ct1_2.getProperties().add(new Property("prop1", "value2"));
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1_1, ct1_2));
 
         Criteria criteria = new Criteria();
-        criteria.getFaults().add(new FaultCriteria("TestFault", null));
+        criteria.addProperty(Constants.PROP_FAULT, "TestFault", Criteria.Operator.HAS);
         criteria.setBusinessTransaction(BTXN).setStartTime(1000).setEndTime(10000);
 
         Wait.until(() ->
@@ -1169,13 +1168,13 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_2.setBusinessTransaction(BTXN);
         ct1_2.setTimestamp(1600);
         ct1_2.setDuration(300);
-        ct1_2.setFault("TestFault");
+        ct1_2.getProperties().add(new Property(Constants.PROP_FAULT, "TestFault"));
         ct1_2.getProperties().add(new Property("prop1", "value2"));
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1_1, ct1_2));
 
         Criteria criteria = new Criteria();
-        criteria.getFaults().add(new FaultCriteria("TestFault", Operator.HASNOT));
+        criteria.addProperty(Constants.PROP_FAULT, "TestFault", Operator.HASNOT);
         criteria.setBusinessTransaction(BTXN).setStartTime(1000).setEndTime(10000);
 
         Wait.until(() ->
@@ -1232,19 +1231,19 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setBusinessTransaction(BTXN);
         ct1_1.setTimestamp(1500);
         ct1_1.setDuration(100);
-        ct1_1.setFault("fault1");
+        ct1_1.getProperties().add(new Property(Constants.PROP_FAULT, "fault1"));
 
         CompletionTime ct1_2 = new CompletionTime();
         ct1_2.setBusinessTransaction(BTXN);
         ct1_2.setTimestamp(1600);
         ct1_2.setDuration(300);
-        ct1_2.setFault("fault2");
+        ct1_2.getProperties().add(new Property(Constants.PROP_FAULT, "fault2"));
 
         CompletionTime ct2 = new CompletionTime();
         ct2.setBusinessTransaction(BTXN);
         ct2.setTimestamp(2100);
         ct2.setDuration(500);
-        ct2.setFault("fault2");
+        ct2.getProperties().add(new Property(Constants.PROP_FAULT, "fault2"));
 
         analytics.storeTraceCompletionTimes(null, Arrays.asList(ct1_1, ct1_2, ct2));
 
@@ -1257,10 +1256,10 @@ public class AnalyticsServiceElasticsearchTest {
         assertNotNull(cards1);
         assertEquals(2, cards1.size());
 
-        assertEquals("fault2", cards1.get(0).getValue());
-        assertEquals(2, cards1.get(0).getCount());
-        assertEquals("fault1", cards1.get(1).getValue());
-        assertEquals(1, cards1.get(1).getCount());
+        assertEquals("fault1", cards1.get(0).getValue());
+        assertEquals(1, cards1.get(0).getCount());
+        assertEquals("fault2", cards1.get(1).getValue());
+        assertEquals(2, cards1.get(1).getCount());
     }
 
     @Test
@@ -1269,7 +1268,7 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setBusinessTransaction(BTXN);
         ct1_1.setTimestamp(1500);
         ct1_1.setDuration(100);
-        ct1_1.setFault("fault1");
+        ct1_1.getProperties().add(new Property(Constants.PROP_FAULT, "fault1"));
 
         CompletionTime ct1_2 = new CompletionTime();
         ct1_2.setBusinessTransaction(BTXN);
@@ -1302,14 +1301,14 @@ public class AnalyticsServiceElasticsearchTest {
         ct1_1.setBusinessTransaction(BTXN);
         ct1_1.setTimestamp(1500);
         ct1_1.setDuration(100);
-        ct1_1.setFault("fault1");
+        ct1_1.getProperties().add(new Property(Constants.PROP_FAULT, "fault1"));
         ct1_1.setPrincipal("p1");
 
         CompletionTime ct1_2 = new CompletionTime();
         ct1_2.setBusinessTransaction(BTXN);
         ct1_2.setTimestamp(1600);
         ct1_2.setDuration(300);
-        ct1_2.setFault("fault2");
+        ct1_2.getProperties().add(new Property(Constants.PROP_FAULT, "fault2"));
         ct1_2.setPrincipal("p2");
 
         CompletionTime ct2 = new CompletionTime();

--- a/server/processors-alerts-publisher/src/main/java/org/hawkular/apm/processor/alerts/Event.java
+++ b/server/processors-alerts-publisher/src/main/java/org/hawkular/apm/processor/alerts/Event.java
@@ -61,10 +61,6 @@ public class Event {
             });
         }
 
-        if (completionTime.getFault() != null && !completionTime.getFault().isEmpty()) {
-            this.tags.put("fault", completionTime.getFault());
-        }
-
         this.category = eventSource;
         this.dataSource = "APM";
         this.id = UUID.randomUUID().toString();

--- a/server/processors-alerts-publisher/src/test/java/org/hawkular/apm/processor/alerts/EventTest.java
+++ b/server/processors-alerts-publisher/src/test/java/org/hawkular/apm/processor/alerts/EventTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Clock;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.junit.Test;
@@ -34,9 +35,10 @@ public class EventTest {
     @Test
     public void eventConsumesFault() {
         CompletionTime completionTime = new CompletionTime();
-        completionTime.setFault("the fault");
+        completionTime.getProperties().add(new Property(Constants.PROP_FAULT, "the fault"));
         Event event = new Event(completionTime, "eventConsumesFault");
-        assertEquals(event.getTags().get("fault"), completionTime.getFault());
+        assertEquals(event.getTags().get(Constants.PROP_FAULT),
+                completionTime.getProperties().iterator().next().getValue());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/CompletionTimeUtil.java
+++ b/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/CompletionTimeUtil.java
@@ -52,7 +52,7 @@ public class CompletionTimeUtil {
         completionTime.setDuration(TimeUnit.MILLISECONDS.convert(span.getDuration(), TimeUnit.MICROSECONDS));
 
         completionTime.setOperation(SpanDeriverUtil.deriveOperation(span));
-        completionTime.setFault(SpanDeriverUtil.deriveFault(span));
+        completionTime.getProperties().add(new Property(Constants.PROP_FAULT, SpanDeriverUtil.deriveFault(span)));
 
         completionTime.setHostAddress(span.ipv4());
         if (span.service() != null) {

--- a/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/NodeDetailsDeriver.java
+++ b/server/processors-zipkin/src/main/java/org/hawkular/apm/server/processor/zipkin/NodeDetailsDeriver.java
@@ -69,7 +69,7 @@ public class NodeDetailsDeriver extends AbstractProcessor<Span, NodeDetails> {
             nd.getProperties().add(new Property(Constants.PROP_SERVICE_NAME, item.service()));
         }
 
-        nd.setFault(SpanDeriverUtil.deriveFault(item));
+        nd.getProperties().add(new Property(Constants.PROP_FAULT, SpanDeriverUtil.deriveFault(item)));
         nd.setOperation(SpanDeriverUtil.deriveOperation(item));
 
         if (log.isLoggable(Level.FINEST)) {

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
@@ -62,7 +62,6 @@ public class FragmentCompletionTimeDeriver extends AbstractProcessor<Trace, Comp
             ct.setBusinessTransaction(item.getBusinessTransaction());
             ct.setDuration(item.calculateDuration());
             ct.setPrincipal(item.getPrincipal());
-            ct.setFault(n.getFault());
             ct.setHostName(item.getHostName());
             ct.setProperties(item.allProperties());
             ct.setTimestamp(item.getStartTime());

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/nodedetails/NodeDetailsDeriver.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/nodedetails/NodeDetailsDeriver.java
@@ -120,10 +120,6 @@ public class NodeDetailsDeriver extends AbstractProcessor<Trace, NodeDetails> {
                     nd.setComponentType(n.getType().name());
                 }
 
-                if (n.getFault() != null && !n.getFault().trim().isEmpty()) {
-                    nd.setFault(n.getFault());
-                }
-
                 if (trace.getHostName() != null && !trace.getHostName().trim().isEmpty()) {
                     nd.setHostName(trace.getHostName());
                 }

--- a/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiator.java
+++ b/server/processors/src/main/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiator.java
@@ -73,7 +73,6 @@ public class TraceCompletionInformationInitiator extends
                 ct.setBusinessTransaction(item.getBusinessTransaction());
                 ct.setDuration(item.calculateDuration());
                 ct.setPrincipal(item.getPrincipal());
-                ct.setFault(n.getFault());
                 ct.setProperties(item.allProperties());
                 ct.setTimestamp(item.getStartTime());
 

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/fragmentcompletiontime/FragmentCompletionTimeDeriverTest.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/fragmentcompletiontime/FragmentCompletionTimeDeriverTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.hawkular.apm.api.model.Constants;
+import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.events.CompletionTime;
 import org.hawkular.apm.api.model.trace.Consumer;
 import org.hawkular.apm.api.model.trace.Trace;
@@ -44,7 +46,7 @@ public class FragmentCompletionTimeDeriverTest {
         c.setUri("uri");
         c.setBaseTime(1);
         c.setDuration(200000000);
-        c.setFault("myFault");
+        c.getProperties().add(new Property(Constants.PROP_FAULT, "myFault"));
         c.setEndpointType("HTTP");
 
         trace.getNodes().add(c);
@@ -68,7 +70,7 @@ public class FragmentCompletionTimeDeriverTest {
         assertEquals(trace.getStartTime(), ct.getTimestamp());
         assertEquals(c.getUri(), ct.getUri());
         assertEquals(200, ct.getDuration());
-        assertEquals(c.getFault(), ct.getFault());
+        assertEquals(c.getProperties(Constants.PROP_FAULT), ct.getProperties(Constants.PROP_FAULT));
     }
 
     @Test

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiatorTest.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiatorTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.hawkular.apm.api.model.Constants;
+import org.hawkular.apm.api.model.Property;
 import org.hawkular.apm.api.model.trace.Component;
 import org.hawkular.apm.api.model.trace.Consumer;
 import org.hawkular.apm.api.model.trace.Producer;
@@ -76,7 +78,7 @@ public class TraceCompletionInformationInitiatorTest {
         c.setUri("uri");
         c.setBaseTime(1);
         c.setDuration(200000000);
-        c.setFault("myFault");
+        c.getProperties().add(new Property(Constants.PROP_FAULT, "myFault"));
         c.setEndpointType("HTTP");
 
         trace.getNodes().add(c);
@@ -102,7 +104,8 @@ public class TraceCompletionInformationInitiatorTest {
         assertEquals(trace.getStartTime(), ci.getCompletionTime().getTimestamp());
         assertEquals(c.getUri(), ci.getCompletionTime().getUri());
         assertEquals(200, ci.getCompletionTime().getDuration());
-        assertEquals(c.getFault(), ci.getCompletionTime().getFault());
+        assertEquals(1, ci.getCompletionTime().getProperties(Constants.PROP_FAULT).size());
+        assertEquals(c.getProperties(Constants.PROP_FAULT), ci.getCompletionTime().getProperties(Constants.PROP_FAULT));
     }
 
     @Test
@@ -116,7 +119,7 @@ public class TraceCompletionInformationInitiatorTest {
         c.setUri("uri");
         c.setBaseTime(1);
         c.setDuration(200000000);
-        c.setFault("myFault");
+        c.getProperties().add(new Property(Constants.PROP_FAULT, "myFault"));
 
         trace.getNodes().add(c);
 
@@ -139,7 +142,9 @@ public class TraceCompletionInformationInitiatorTest {
         assertEquals(trace.getStartTime(), ci.getCompletionTime().getTimestamp());
         assertEquals(EndpointUtil.encodeClientURI(c.getUri()), ci.getCompletionTime().getUri());
         assertEquals(200, ci.getCompletionTime().getDuration());
-        assertEquals(c.getFault(), ci.getCompletionTime().getFault());
+        assertEquals(c.getProperties(Constants.PROP_FAULT), ci.getCompletionTime().getProperties(Constants.PROP_FAULT));
+        assertEquals(1, ci.getCompletionTime().getProperties(Constants.PROP_FAULT).size());
+
     }
 
     @Test

--- a/server/rest/src/main/java/org/hawkular/apm/server/rest/RESTServiceUtil.java
+++ b/server/rest/src/main/java/org/hawkular/apm/server/rest/RESTServiceUtil.java
@@ -21,7 +21,6 @@ import java.util.StringTokenizer;
 
 import org.hawkular.apm.api.model.trace.CorrelationIdentifier;
 import org.hawkular.apm.api.model.trace.CorrelationIdentifier.Scope;
-import org.hawkular.apm.api.services.Criteria.FaultCriteria;
 import org.hawkular.apm.api.services.Criteria.Operator;
 import org.hawkular.apm.api.services.Criteria.PropertyCriteria;
 import org.jboss.logging.Logger;
@@ -93,31 +92,4 @@ public class RESTServiceUtil {
         }
     }
 
-    /**
-     * This method decodes a set of faults.
-     *
-     * @param faults The faults
-     * @param encoded The string containing the encoded faults
-     */
-    public static void decodeFaults(Set<FaultCriteria> faults, String encoded) {
-        if (encoded != null && !encoded.trim().isEmpty()) {
-            StringTokenizer st = new StringTokenizer(encoded, ",");
-            while (st.hasMoreTokens()) {
-                String fault = st.nextToken();
-                String[] parts = fault.split("[|]");
-                if (parts.length >= 1) {
-                    String value = parts[0].trim();
-                    Operator op = Operator.HAS;
-
-                    if (parts.length > 1) {
-                        op = Operator.valueOf(parts[1].trim());
-                    }
-
-                    log.tracef("Extracted fault value [%s] operator [%s]", value, op);
-
-                    faults.add(new FaultCriteria(value, op));
-                }
-            }
-        }
-    }
 }

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterAsyncITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterAsyncITest.java
@@ -264,7 +264,8 @@ public class ClientJettyReaderWriterAsyncITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals("401", testProducer.getFault());
+            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
+            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("Unauthorized", testProducer.getDetails().get(Constants.DETAIL_FAULT_DESCRIPTION));
         } else {
 

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterITest.java
@@ -262,7 +262,8 @@ public class ClientJettyReaderWriterITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals("401", testProducer.getFault());
+            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
+            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("Unauthorized", testProducer.getDetails().get(Constants.DETAIL_FAULT_DESCRIPTION));
         } else {
 

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamAsyncITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamAsyncITest.java
@@ -267,7 +267,8 @@ public class ClientJettyStreamAsyncITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals("401", testProducer.getFault());
+            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
+            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("Unauthorized", testProducer.getDetails().get(Constants.DETAIL_FAULT_DESCRIPTION));
         } else {
 

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamITest.java
@@ -217,7 +217,7 @@ public class ClientJettyStreamITest extends ClientTestBase {
         Producer testProducer = producers.get(0);
 
         assertEquals(path, testProducer.getUri());
-        assertEquals("ConnectException", producers.get(0).getFault());
+        assertEquals("ConnectException", producers.get(0).getProperties(Constants.PROP_FAULT).iterator().next().getValue());
         assertEquals("Connection refused", producers.get(0).getDetails().get(Constants.DETAIL_FAULT_DESCRIPTION));
     }
 
@@ -354,7 +354,8 @@ public class ClientJettyStreamITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals("401", testProducer.getFault());
+            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
+            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("Unauthorized", testProducer.getDetails().get(Constants.DETAIL_FAULT_DESCRIPTION));
         } else {
 

--- a/tests/dist/src/test/java/org/hawkular/apm/tests/dist/AnalyticsServiceITest.java
+++ b/tests/dist/src/test/java/org/hawkular/apm/tests/dist/AnalyticsServiceITest.java
@@ -412,7 +412,7 @@ public class AnalyticsServiceITest extends AbstractITest {
         trace1.setStartTime(System.currentTimeMillis() - 4000); // Within last hour
         Consumer c1 = new Consumer();
         c1.setUri("testuri");
-        c1.setFault("Failed");
+        c1.getProperties().add(new Property(Constants.PROP_FAULT, "Failed"));
         trace1.getNodes().add(c1);
 
         List<Trace> traces = new ArrayList<Trace>();
@@ -495,7 +495,7 @@ public class AnalyticsServiceITest extends AbstractITest {
         trace1.setStartTime(System.currentTimeMillis() - 4000); // Within last hour
         Consumer c1 = new Consumer();
         c1.setUri("testuri1");
-        c1.setFault(MY_FAULT);
+        c1.getProperties().add(new Property(Constants.PROP_FAULT, MY_FAULT));
         c1.getProperties().add(new Property("prop2", "hello"));
         trace1.getNodes().add(c1);
 
@@ -538,8 +538,8 @@ public class AnalyticsServiceITest extends AbstractITest {
 
         CompletionTime ct = times.get(0);
         assertEquals("1", ct.getId());
-        assertNotNull(ct.getFault());
-        assertEquals(MY_FAULT, ct.getFault());
+        assertEquals(1, ct.getProperties(Constants.PROP_FAULT).size());
+        assertEquals(MY_FAULT, ct.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
     }
 
     @Test
@@ -632,7 +632,7 @@ public class AnalyticsServiceITest extends AbstractITest {
         Consumer c1 = new Consumer();
         c1.setUri("testuri");
         c1.setDuration(1000000);
-        c1.setFault("fault1");
+        c1.getProperties().add(new Property(Constants.PROP_FAULT, "fault1"));
         trace1.getNodes().add(c1);
 
         List<Trace> traces = new ArrayList<Trace>();

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/ApacheHttpClientITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/ApacheHttpClientITest.java
@@ -226,7 +226,8 @@ public class ApacheHttpClientITest extends ClientTestBase {
         assertFalse("testProducer has no headers", testProducer.getIn().getHeaders().isEmpty());
 
         if (fault) {
-            assertEquals("401", testProducer.getFault());
+            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
+            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("Unauthorized", testProducer.getDetails().get(Constants.DETAIL_FAULT_DESCRIPTION));
         } else {
 

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JBossRESTEasyClientITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JBossRESTEasyClientITest.java
@@ -31,6 +31,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import org.hawkular.apm.api.model.Constants;
 import org.hawkular.apm.api.model.trace.Producer;
 import org.hawkular.apm.api.model.trace.Trace;
 import org.hawkular.apm.api.utils.NodeUtil;
@@ -208,7 +209,8 @@ public class JBossRESTEasyClientITest extends ClientTestBase {
         assertFalse("testProducer has no headers", testProducer.getIn().getHeaders().isEmpty());
 
         if (fault) {
-            assertEquals("401", testProducer.getFault());
+            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
+            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
 
             // TODO: Awaitin fix for HWKBTM-151
             //assertEquals("Unauthorized", testProducer.getFaultDescription());

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JavaNetHttpITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JavaNetHttpITest.java
@@ -312,7 +312,8 @@ public class JavaNetHttpITest extends ClientTestBase {
         assertFalse("testProducer has no headers", testProducer.getIn().getHeaders().isEmpty());
 
         if (fault) {
-            assertEquals("401", testProducer.getFault());
+            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
+            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("Unauthorized", testProducer.getDetails().get(Constants.DETAIL_FAULT_DESCRIPTION));
         } else {
 

--- a/ui/src/main/scripts/plugins/apm/ts/apm.ts
+++ b/ui/src/main/scripts/plugins/apm/ts/apm.ts
@@ -218,14 +218,6 @@ module APM {
       $rootScope.sbFilter.criteria.properties.splice($rootScope.sbFilter.criteria.properties.indexOf(property), 1);
     };
 
-    $scope.addFaultToFilter = function(fault, operator) {
-      $rootScope.sbFilter.criteria.faults.push({value: fault, operator: operator});
-    };
-
-    $scope.remFaultFromFilter = function(fault) {
-      $rootScope.sbFilter.criteria.faults.splice($rootScope.sbFilter.criteria.faults.indexOf(fault), 1);
-    };
-
     $scope.toggleExcludeInclude = function(propOrFault) {
       if (propOrFault.operator === undefined || propOrFault.operator === 'HAS') {
         propOrFault.operator = 'HASNOT';

--- a/ui/src/main/scripts/plugins/btm/html/btxninfo.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxninfo.html
@@ -15,26 +15,6 @@
         <div class="card-pf-body">
 
           <div class="form-group" >
-            <span ng-repeat="fault in criteria.faults">
-              <span ng-show="fault.operator === undefined || fault.operator === 'HAS'">
-                <a class="btn btn-success" ng-click="toggleExclusion(fault)">
-                  <i>fault</i>: {{fault.value}}
-                  <a class="btn btn-default" ng-click="removeFault(fault)">
-                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                  </a>
-                </a>
-              </span>
-              <span ng-show="fault.operator === 'HASNOT'">
-                <a class="btn btn-danger" ng-click="toggleExclusion(fault)">
-                  <i>fault</i>: {{fault.value}}
-                  <a class="btn btn-default" ng-click="removeFault(fault)">
-                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                  </a>
-                </a>
-              </span>
-              <label style="width: 1%" ></label> <!-- TODO: Must be a better way -->
-            </span>
-
             <span ng-repeat="property in criteria.properties">
               <span ng-show="property.operator === undefined || property.operator === 'HAS'">
                 <a class="btn btn-success" ng-click="toggleExclusion(property)">
@@ -145,7 +125,7 @@
             <select name="propertyField" class="form-control"
               ng-model="config.selectedProperty" ng-change="reloadProperty()" ng-show="properties.length">
               <option value="" disabled>Select a property</option>
-              <option ng-repeat="property in properties">{{property.name}}</option>
+              <option ng-repeat="property in properties | filter:{name: '!fault'}">{{property.name}}</option>
             </select>
           </div>
         </div>

--- a/ui/src/main/scripts/plugins/btm/ts/btxninfo.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btxninfo.ts
@@ -34,7 +34,6 @@ module BTM {
     $scope.criteria = {
       businessTransaction: $scope.businessTransactionName,
       properties: [],
-      faults: [],
       startTime: '-3600000',
       endTime: '0',
       lowerBound: 0
@@ -124,7 +123,7 @@ module BTM {
         columns: $scope.faultData,
         type: 'pie',
         onclick: function(d, i) {
-          let added = addIfAbsent($scope.criteria.faults, undefined, d.id);
+          let added = addIfAbsent($scope.criteria.properties, 'fault', d.id);
           if (added) {
             $scope.reload();
           }

--- a/ui/src/main/scripts/plugins/directives/filter-sidebar/html/filter-sidebar.html
+++ b/ui/src/main/scripts/plugins/directives/filter-sidebar/html/filter-sidebar.html
@@ -106,41 +106,6 @@
       </div>
     </div>
 
-    <div class="hk-filter-v-block" ng-if="fsb.showFaults">
-      <label><button class="btn-link" ng-click="showSearchFault = !showSearchFault"><i class="fa" ng-class="showSearchFault ? 'fa-angle-right' : 'fa-angle-down'"></i>Faults</button></label>
-      <div collapse="showSearchFault">
-
-        <ul ng-repeat="fault in $root.sbFilter.criteria.faults" class="fa-ul">
-          <li class="sb-prop" ng-click="toggleExcludeInclude(fault)">
-            <span class="hk-cursor-pointer">
-              <i class="fa-li fa" aria-hidden="true"
-                ng-class="fault.operator === 'HASNOT' ? 'fa-minus-square sb-toggle-exc' : 'fa-plus-square sb-toggle-inc'"></i>
-            </span>
-            {{ fault.value }}
-            <span class="hk-cursor-pointer pull-right sb-prop-remove" ng-click="remFaultFromFilter(fault)">
-              <i class="fa fa-remove"></i>
-            </span>
-          </li>
-        </ul>
-
-        <div class="radio" style="margin-left: 0px;">
-          <div class="input-group">
-            <select class="form-control" ng-options="f.value for f in $root.sbFilter.data.faults track by f.value" ng-model="selFault"></select>
-            <div class="input-group-btn">
-              <button type="button" class="btn btn-default" ng-disabled="!selFault"
-                ng-click="addFaultToFilter(selFault.value, 'HAS')">
-                <i class="fa fa-plus sb-prop-incexc"></i>
-              </button>
-              <button type="button" class="btn btn-default" ng-disabled="!selFault"
-                ng-click="addFaultToFilter(selFault.value, 'HASNOT')">
-                <i class="fa fa-minus sb-prop-incexc"></i>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <div class="hk-filter-v-block" ng-if="fsb.showText">
       <label class="hk-label-heading">Text</label>
       <input type="text" class="form-control" placeholder="Contains text" ng-model="$root.sbFilter.search"/>

--- a/ui/src/main/scripts/plugins/directives/filter-sidebar/ts/filterSidebarDirective.ts
+++ b/ui/src/main/scripts/plugins/directives/filter-sidebar/ts/filterSidebarDirective.ts
@@ -53,7 +53,6 @@ module FilterSidebar {
         businessTransaction: '',
         hostName: '',
         properties: [],
-        faults: [],
         startTime: $rootScope.timeSpans[4].time,
         endTime: '0'
       };
@@ -160,15 +159,6 @@ module FilterSidebar {
           this.$rootScope.sbFilter.data.properties = resp.data || [];
         }, (error) => {
             console.log('Failed to get properties: ' + angular.toJson(error));
-        });
-      }
-
-      if (scope.fsb.showFaults) {
-        this.$http.get('/hawkular/apm/analytics/trace/completion/faults?criteria=' +
-            encodeURI(angular.toJson(this.$rootScope.sbFilter.criteria))).then((resp) => {
-          this.$rootScope.sbFilter.data.faults = resp.data || [];
-        }, (error) => {
-            console.log('Failed to get faults: ' + angular.toJson(error));
         });
       }
 

--- a/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
+++ b/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
@@ -106,14 +106,6 @@ module E2E {
       $rootScope.sbFilter.criteria.properties.splice($rootScope.sbFilter.criteria.properties.indexOf(property), 1);
     };
 
-    $scope.addFaultToFilter = function(fault, operator) {
-      $rootScope.sbFilter.criteria.faults.push({value: fault, operator: operator});
-    };
-
-    $scope.remFaultFromFilter = function(fault) {
-      $rootScope.sbFilter.criteria.faults.splice($rootScope.sbFilter.criteria.faults.indexOf(fault), 1);
-    };
-
     $scope.toggleExcludeInclude = function(propOrFault) {
       if (propOrFault.operator === undefined || propOrFault.operator === 'HAS') {
         propOrFault.operator = 'HASNOT';


### PR DESCRIPTION
…r of reporting faults as a property. This enables multiple faults, reported at different stages of the trace instance, to be collectively associated with the trace instance. This has resulted in fault filtering being removed from the criteria, so a property filter is used instead.