### PR TITLE
HWKAPM-717 : Fix toggling between initial nodes

### DIFF
--- a/ui/src/main/scripts/plugins/directives/dagre-d3/ts/dagreD3Directive.ts
+++ b/ui/src/main/scripts/plugins/directives/dagre-d3/ts/dagreD3Directive.ts
@@ -68,11 +68,8 @@ module DagreD3 {
         nodeTooltip += ' / ' + (d.minimumDuration / 1000) + ' / ' + (d.maximumDuration / 1000);
         let html = '<div' + (d.count ? (' tooltip-append-to-body="true" tooltip-class="graph-tooltip"' +
           'tooltip-html-unsafe="' + nodeTooltip + '"') : '') + '>';
-        if (d.serviceName == null) {
-          d.serviceName = '&zwnj;';
-        }
         html += '<span class="status"></span>';
-        html += '<span class="name service-name">' + d.serviceName + '</span>';
+        html += '<span class="name service-name">' + (d.serviceName || '&nbsp;') + '</span>';
         html += '<span class="name">' + d.id + '</span>';
         html += '<span class="stats">';
         html += '  <span class="duration pull-left"><i class="fa fa-clock-o"></i>' +


### PR DESCRIPTION
When toggling between initial nodes, there were an invisible string
being added to serviceName, which caused issues later when try to match
the selected node with the one in the list.

This fixes it, doesn't add the character and changes the way lack of
serviceName is displayed.