### PR TITLE
HWKAPM-580 : Instance Details table enhancements

### DIFF
--- a/ui/src/main/scripts/plugins/e2e/html/details-modal.html
+++ b/ui/src/main/scripts/plugins/e2e/html/details-modal.html
@@ -41,40 +41,40 @@
   </div>
   <div class="row">
     <div class="col-md-12">
-      <table class="datatable table table-striped table-bordered" style="table-layout: fixed">
+      <table class="datatable table table-striped table-bordered inst-details-table">
         <thead>
           <tr>
-            <th ng-click="sort('timestamp')" style="width: 180px;">Timestamp
+            <th class="inst-details-timestamp" ng-click="sort('timestamp')">Timestamp
               <span class="glyphicon sort-icon" ng-show="sortKey=='timestamp'" ng-class="{'glyphicon-chevron-up':reverse,'glyphicon-chevron-down':!reverse}"></span>
             </th>
             <!--<th ng-click="sort('uri')">URL
               <span class="glyphicon sort-icon" ng-show="sortKey=='uri'" ng-class="{'glyphicon-chevron-up':reverse,'glyphicon-chevron-down':!reverse}"></span>
             </th>-->
-            <th ng-click="sort('properties')" style="width: 50%">Properties
+            <th class="inst-details-properties" ng-click="sort('properties')">Properties
               <span class="glyphicon sort-icon" ng-show="sortKey=='properties'" ng-class="{'glyphicon-chevron-up':reverse,'glyphicon-chevron-down':!reverse}"></span>
             </th>
-            <th ng-click="sort('principal')" style="width: 15%">Principal
+            <th class="inst-details-principal" ng-click="sort('principal')">Principal
               <span class="glyphicon sort-icon" ng-show="sortKey=='principal'" ng-class="{'glyphicon-chevron-up':reverse,'glyphicon-chevron-down':!reverse}"></span>
             </th>
-            <th ng-click="sort('duration')">Duration (ms)
+            <th class="inst-details-duration" ng-click="sort('duration')">Duration (ms)
               <span class="glyphicon sort-icon" ng-show="sortKey=='duration'" ng-class="{'glyphicon-chevron-up':reverse,'glyphicon-chevron-down':!reverse}"></span>
             </th>
-            <th>Details
+            <th class="inst-details-details">Details
             </th>
           </tr>
         </thead>
         <tbody>
           <tr dir-paginate-start="tData in filteredData = (timesData | filter:tableFilter | filter:durationRange | orderBy:sortKey:reverse) | itemsPerPage:numPerPage" ng-show="!selectedTx || selectedTx === tData.id">
-            <td>{{ tData.timestamp | date:'medium' }}</td>
+            <td class="inst-details-timestamp">{{ tData.timestamp | date:'medium' }}</td>
             <!--<td>{{ tData.uri }}</td>-->
-            <td style="overflow: hidden">
-              <span class="label label-default" style="margin: 1px; display: inline-block" ng-repeat="tDataProp in tData.properties">
-                {{tDataProp.name}}:{{tDataProp.value}}
+            <td class="inst-details-properties">
+              <span class="label label-default" ng-repeat="tDataProp in tData.properties" ng-click="tDataProp.expand = !tDataProp.expand" tooltip="{{tDataProp.name}} : {{tDataProp.value}}">
+                {{tDataProp.name}}:<span ng-hide="tDataProp.expand">{{ tDataProp.value | limitTo:16}}<span ng-show="!tDataProp.expand && tDataProp.value.length > 16">...</span></span><span ng-show="tDataProp.expand">{{ tDataProp.value }}</span>
               </span>
             </td>
-            <td style="word-wrap: break-word">{{ tData.principal }}</td>
-            <td style="word-wrap: break-word">{{ tData.duration / 1000 }}</td>
-            <td class="show-details-cell" ng-click="showIVD(tData.id)"><i class="fa fa-sitemap"></i></td>
+            <td class="inst-details-principal">{{ tData.principal }}</td>
+            <td class="inst-details-duration">{{ tData.duration / 1000 }}</td>
+            <td class="inst-details-details" ng-click="showIVD(tData.id)"><i class="fa fa-sitemap"></i></td>
           </tr>
           <tr dir-paginate-end ng-if="selectedTx === tData.id">
             <td colspan="5" class="details-row" instance-view-diagram nodes="instDetails">

--- a/ui/src/main/scripts/plugins/e2e/less/e2e.less
+++ b/ui/src/main/scripts/plugins/e2e/less/e2e.less
@@ -255,7 +255,44 @@ th {
     color: #fff;
 }
 
-.show-details-cell {
+/** Instance Details Table styles */
+
+.inst-details-table {
+    table-layout: fixed;
+}
+
+th.inst-details-timestamp {
+    width: 105px;
+}
+
+td.inst-details-properties {
+    overflow: hidden;
+
+    span {
+         margin: 1px;
+         display: inline-block;
+         cursor: pointer;
+    }
+}
+
+th.inst-details-principal {
+    width: 140px;
+}
+td.inst-details-principal {
+    word-wrap: break-word;
+}
+
+th.inst-details-duration {
+    width: 120px;
+}
+td.inst-details-duration {
+    word-wrap: break-word;
+}
+
+th.inst-details-details {
+    width: 60px;
+}
+td.inst-details-details {
     cursor: pointer;
     text-align: center;
 }


### PR DESCRIPTION
- Fixed some rows width to better use available horizontal space (broke timestamp in two lines, decreased duration and details width);
- Collapse long property values (limit at 16 chars). Toggle between collapsed/expanded with click. Tooltip shows whole value;
- Fixed inline styles to CSS classes;

![image](https://cloud.githubusercontent.com/assets/1737954/19940516/da6ae23e-a124-11e6-94ee-f7a51f7e873e.png)

![image](https://cloud.githubusercontent.com/assets/1737954/19940551/f710720a-a124-11e6-85bc-5d0ba36afbc8.png)
