### PR TITLE
HWKAPM-744 Change the dataId from TraceCompletionTime to just TraceCo…

### DIFF
--- a/server/processors-alerts-publisher/src/main/java/org/hawkular/apm/processor/alerts/FragmentCompletionTimeAlertsPublisherMDB.java
+++ b/server/processors-alerts-publisher/src/main/java/org/hawkular/apm/processor/alerts/FragmentCompletionTimeAlertsPublisherMDB.java
@@ -57,7 +57,7 @@ public class FragmentCompletionTimeAlertsPublisherMDB implements MessageListener
         try {
             String data = ((TextMessage) message).getText();
             List<CompletionTime> items = mapper.readValue(data, new TypeReference<List<CompletionTime>>() {});
-            publisher.publish(items, "FragmentCompletionTime");
+            publisher.publish(items, "ServiceCompletion");
         } catch (IOException | JMSException e) {
             logger.errorPublishingToAlerts(e);
         }

--- a/server/processors-alerts-publisher/src/main/java/org/hawkular/apm/processor/alerts/TraceCompletionTimeAlertsPublisherMDB.java
+++ b/server/processors-alerts-publisher/src/main/java/org/hawkular/apm/processor/alerts/TraceCompletionTimeAlertsPublisherMDB.java
@@ -57,7 +57,7 @@ public class TraceCompletionTimeAlertsPublisherMDB implements MessageListener {
         try {
             String data = ((TextMessage) message).getText();
             List<CompletionTime> items = mapper.readValue(data, new TypeReference<List<CompletionTime>>() {});
-            publisher.publish(items, "TraceCompletionTime");
+            publisher.publish(items, "TraceCompletion");
         } catch (IOException | JMSException e) {
             logger.errorPublishingToAlerts(e);
         }


### PR DESCRIPTION
…mpletion to better reflect the nature of the event. Also changed FragmentCompletionTime to ServiceCompletion, as activity performed within a service may be concurrent and therefore recorded in multiple fragments - but it is the overall time spent in the service that is of interest