### PR TITLE
itest opentracing polyglot app, JS provider use fixed versions

### DIFF
--- a/tests/app/polyglot-opentracing/js/index.js
+++ b/tests/app/polyglot-opentracing/js/index.js
@@ -29,7 +29,7 @@ const CONTEXT_PATH = '/nodejs';
 
 opentracing.initGlobalTracer(new hawkularAPM.APMTracer({
     recorder: new hawkularAPM.HttpRecorder('http://hawkular-apm:9080', 'jdoe', 'password'),
-    sampler: new hawkularAPM.AlwaysSampledSampler(),
+    sampler: new hawkularAPM.AlwaysSample(),
 }));
 
 // /hello handler

--- a/tests/app/polyglot-opentracing/js/package.json
+++ b/tests/app/polyglot-opentracing/js/package.json
@@ -16,7 +16,7 @@
     "babel-preset-node6": "^11.0.0",
     "babel-preset-es2015": "^6.13.2",
     "httpdispatcher": "^1.1.0",
-    "opentracing": "^0.13.0",
-    "hawkular-apm-opentracing": "^0.1.1"
+    "opentracing": "0.13.0",
+    "hawkular-apm-opentracing": "0.1.4"
   }
 }


### PR DESCRIPTION
@objectiser could you please review? 

Now it will use fixed versions of JS dependencies.

https://docs.npmjs.com/files/package.json#dependencies

