### PR TITLE
HWKAPM-775 Only define 'client' prefix on endpoints where fragment on…

### DIFF
--- a/api/src/test/java/org/hawkular/apm/api/utils/EndpointUtilTest.java
+++ b/api/src/test/java/org/hawkular/apm/api/utils/EndpointUtilTest.java
@@ -96,6 +96,8 @@ public class EndpointUtilTest {
     @Test
     public void testGetSourceEndpointConsumer() {
         Trace trace = new Trace();
+        trace.setTraceId("1");
+        trace.setFragmentId(trace.getTraceId());
         Consumer consumer = new Consumer();
         consumer.setUri(URI);
         consumer.setOperation(OPERATION);
@@ -110,6 +112,8 @@ public class EndpointUtilTest {
     @Test
     public void testGetSourceEndpointClientProducer() {
         Trace trace = new Trace();
+        trace.setTraceId("1");
+        trace.setFragmentId(trace.getTraceId());
         Producer producer = new Producer();
         producer.setUri(URI);
         producer.setOperation(OPERATION);
@@ -122,39 +126,25 @@ public class EndpointUtilTest {
     }
 
     @Test
-    public void testGetSourceEndpointClientComponent() {
+    public void testGetSourceEndpointNotClientComponentProducer() {
+        // As this initial fragment does not have a single Producer node,
+        // its endpoint ref will be based on the component's URI and operation
         Trace trace = new Trace();
+        trace.setTraceId("1");
+        trace.setFragmentId(trace.getTraceId());
         Component component = new Component();
         component.setUri(URI);
         component.setOperation(OPERATION);
         trace.getNodes().add(component);
 
-        EndpointRef ep = EndpointUtil.getSourceEndpoint(trace);
-
-        assertNotNull(ep);
-        assertEquals(new EndpointRef(URI, OPERATION, true), ep);
-    }
-
-    @Test
-    public void testGetSourceEndpointClientComponentProducer() {
-
-        // Currently the 'source endpoint' for this fragment will be based on the producer
-        // URI and operation, although this may be changed following discussion in HWKAPM-660
-
-        Trace trace = new Trace();
-        Component component = new Component();
-        component.setUri("otheruri");
-        component.setOperation("otherop");
-        trace.getNodes().add(component);
-
         Producer producer = new Producer();
-        producer.setUri(URI);
-        producer.setOperation(OPERATION);
+        producer.setUri("otheruri");
+        producer.setOperation("otherop");
         component.getNodes().add(producer);
 
         EndpointRef ep = EndpointUtil.getSourceEndpoint(trace);
 
         assertNotNull(ep);
-        assertEquals(new EndpointRef(URI, OPERATION, true), ep);
+        assertEquals(new EndpointRef(URI, OPERATION, false), ep);
     }
 }

--- a/server/api/src/test/java/org/hawkular/apm/server/api/utils/SourceInfoUtilTest.java
+++ b/server/api/src/test/java/org/hawkular/apm/server/api/utils/SourceInfoUtilTest.java
@@ -53,7 +53,8 @@ public class SourceInfoUtilTest {
     @Test
     public void testInitialiseIds() throws RetryAttemptException {
         Trace trace = new Trace();
-        trace.setFragmentId("trace1");
+        trace.setTraceId("trace1");
+        trace.setFragmentId(trace.getTraceId());
 
         Consumer consumer1 = new Consumer();
         consumer1.setUri("uri1");
@@ -100,19 +101,18 @@ public class SourceInfoUtilTest {
     @Test
     public void testInitialiseFragmentOrigins() throws RetryAttemptException {
         Trace trace1 = new Trace();
-        trace1.setFragmentId("trace1");
-
-        Component component1 = new Component();
-        trace1.getNodes().add(component1);
+        trace1.setTraceId("1");
+        trace1.setFragmentId(trace1.getTraceId());
 
         Producer producer1 = new Producer();
         producer1.setUri("uri1");
         producer1.setOperation("op1");
         producer1.addInteractionCorrelationId("in1");
-        component1.getNodes().add(producer1);
+        trace1.getNodes().add(producer1);
 
         Trace trace2 = new Trace();
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("2");
 
         Consumer consumer1 = new Consumer();
         consumer1.setUri("uri1");
@@ -126,24 +126,21 @@ public class SourceInfoUtilTest {
         List<SourceInfo> sourceInfoList = SourceInfoUtil.getSourceInfo(null, Arrays.asList(trace1, trace2));
 
         assertNotNull(sourceInfoList);
-        assertEquals(5, sourceInfoList.size());
+        assertEquals(4, sourceInfoList.size());
 
         SourceInfo si1 = sourceInfoList.get(0);
         SourceInfo si2 = sourceInfoList.get(1);
         SourceInfo si3 = sourceInfoList.get(2);
         SourceInfo si4 = sourceInfoList.get(3);
-        SourceInfo si5 = sourceInfoList.get(4);
 
         assertEquals(EndpointUtil.encodeClientURI("uri1"), si1.getEndpoint().getUri());
         assertEquals("op1", si1.getEndpoint().getOperation());
         assertEquals(EndpointUtil.encodeClientURI("uri1"), si2.getEndpoint().getUri());
         assertEquals("op1", si2.getEndpoint().getOperation());
-        assertEquals(EndpointUtil.encodeClientURI("uri1"), si3.getEndpoint().getUri());
+        assertEquals("uri1", si3.getEndpoint().getUri());
         assertEquals("op1", si3.getEndpoint().getOperation());
         assertEquals("uri1", si4.getEndpoint().getUri());
         assertEquals("op1", si4.getEndpoint().getOperation());
-        assertEquals("uri1", si5.getEndpoint().getUri());
-        assertEquals("op1", si5.getEndpoint().getOperation());
     }
 
     @Test

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriverTest.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriverTest.java
@@ -419,8 +419,6 @@ public class CommunicationDetailsDeriverTest {
         trace1.setTransaction(TXN_NAME);
         trace1.setTraceId("abc");
         trace1.setFragmentId(trace1.getTraceId());
-        trace1.setHostName("host1");
-        trace1.setHostAddress("addr1");
 
         Consumer c1 = new Consumer();
         c1.setUri("FirstURI");
@@ -455,14 +453,11 @@ public class CommunicationDetailsDeriverTest {
         trace2.setTransaction(TXN_NAME);
         trace2.setTraceId(trace1.getTraceId());
         trace2.setFragmentId("def");
-        trace2.setHostName("host2");
-        trace2.setHostAddress("addr2");
 
         Consumer c2 = new Consumer();
         c2.setUri("SecondURI");
         c2.setDuration(1200000000);
         c2.getProperties().add(new Property(Consumer.PROPERTY_PUBLISH, "true"));
-        c2.getProperties().add(new Property("prop1", "value1"));
 
         CorrelationIdentifier cid2 = new CorrelationIdentifier();
         cid2.setScope(Scope.Interaction);
@@ -494,11 +489,8 @@ public class CommunicationDetailsDeriverTest {
 
         traces1.add(trace1);
 
-        trace1.setTransaction(TXN_NAME);
         trace1.setTraceId("abc");
         trace1.setFragmentId(trace1.getTraceId());
-        trace1.setHostName("host1");
-        trace1.setHostAddress("addr1");
 
         Consumer c1 = new Consumer();
         c1.setUri("FirstURI");
@@ -530,17 +522,13 @@ public class CommunicationDetailsDeriverTest {
 
         traces2.add(trace2);
 
-        trace2.setTransaction(TXN_NAME);
         trace2.setTraceId(trace1.getTraceId());
         trace2.setFragmentId("def");
-        trace2.setHostName("host2");
-        trace2.setHostAddress("addr2");
 
         Consumer c2 = new Consumer();
         c2.setUri("SecondURI");
         c2.setDuration(1200000000);
         c2.getProperties().add(new Property(Consumer.PROPERTY_PUBLISH, "true"));
-        c2.getProperties().add(new Property("prop1", "value1"));
 
         CorrelationIdentifier cid2 = new CorrelationIdentifier();
         cid2.setScope(Scope.ControlFlow);
@@ -576,14 +564,11 @@ public class CommunicationDetailsDeriverTest {
         trace1.setTransaction(TXN_NAME);
         trace1.setTraceId("1");
         trace1.setFragmentId(trace1.getTraceId());
-        trace1.setHostName("host1");
-        trace1.setHostAddress("addr1");
 
         Producer p1 = new Producer();
         p1.setUri("TheURI");
         p1.setTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()));
         p1.setDuration(2000000);
-        p1.getProperties().add(new Property(Constants.PROP_PRINCIPAL, "p1"));
 
         CorrelationIdentifier pid1 = new CorrelationIdentifier();
         pid1.setScope(Scope.Interaction);
@@ -600,14 +585,10 @@ public class CommunicationDetailsDeriverTest {
         trace2.setTransaction(TXN_NAME);
         trace2.setTraceId(trace1.getTraceId());
         trace2.setFragmentId("2");
-        trace2.setHostName("host2");
-        trace2.setHostAddress("addr2");
 
         Consumer c2 = new Consumer();
         c2.setUri("TheURI");
         c2.setDuration(1200000);
-        c2.getProperties().add(new Property(Constants.PROP_PRINCIPAL, "p1"));
-        c2.getProperties().add(new Property("prop1", "value1"));
 
         CorrelationIdentifier cid2 = new CorrelationIdentifier();
         cid2.setScope(Scope.Interaction);
@@ -629,14 +610,8 @@ public class CommunicationDetailsDeriverTest {
         assertTrue(c2.getDuration() == details.getConsumerDuration());
         assertTrue(p1.getDuration() == details.getProducerDuration());
         assertEquals(400000, details.getLatency());
-        assertTrue(details.hasProperty("prop1"));
         assertEquals(trace1.getFragmentId(), details.getSourceFragmentId());
-        assertEquals("host1", details.getSourceHostName());
-        assertEquals("addr1", details.getSourceHostAddress());
         assertEquals(trace2.getFragmentId(), details.getTargetFragmentId());
-        assertEquals("host2", details.getTargetHostName());
-        assertEquals("addr2", details.getTargetHostAddress());
-        assertEquals("p1", details.getProperties(Constants.PROP_PRINCIPAL).iterator().next().getValue());
     }
 
     @Test
@@ -730,16 +705,12 @@ public class CommunicationDetailsDeriverTest {
         Trace trace1 = new Trace();
         trace1.setTimestamp(1000000);
 
-        trace1.setTransaction(TXN_NAME);
         trace1.setTraceId("abc");
         trace1.setFragmentId(trace1.getTraceId());
-        trace1.setHostName("host1");
-        trace1.setHostAddress("addr1");
 
         Consumer c1 = new Consumer();
         c1.setUri("FirstURI");
         c1.setTimestamp(trace1.getTimestamp());
-        c1.getProperties().add(new Property(Constants.PROP_PRINCIPAL, "p1"));
 
         CorrelationIdentifier cid1 = new CorrelationIdentifier();
         cid1.setScope(Scope.Interaction);
@@ -751,25 +722,19 @@ public class CommunicationDetailsDeriverTest {
         Component comp1 = new Component();
         comp1.setTimestamp(trace1.getTimestamp() + 1000000);
         comp1.setDuration(2000000000);
-        comp1.getProperties().add(new Property("prop1", "value1"));
 
         c1.getNodes().add(comp1);
 
         Trace trace2 = new Trace();
         trace2.setTimestamp(2000000);
 
-        trace2.setTransaction(TXN_NAME);
         trace2.setTraceId(trace1.getTraceId());
         trace2.setFragmentId("def");
-        trace2.setHostName("host2");
-        trace2.setHostAddress("addr2");
 
         Consumer c2 = new Consumer();
         c2.setUri("SecondURI");
         c2.setTimestamp(trace2.getTimestamp());
         c2.setDuration(1200000000);
-        c2.getProperties().add(new Property(Constants.PROP_PRINCIPAL, "p1"));
-        c2.getProperties().add(new Property("prop2", "value2"));
 
         CorrelationIdentifier cid2 = new CorrelationIdentifier();
         cid2.setScope(Scope.CausedBy);
@@ -784,7 +749,6 @@ public class CommunicationDetailsDeriverTest {
 
         assertNotNull(details);
 
-        assertEquals(TXN_NAME, details.getTransaction());
         assertEquals("FirstURI", details.getSource());
         assertEquals("SecondURI", details.getTarget());
 
@@ -796,15 +760,8 @@ public class CommunicationDetailsDeriverTest {
         long latency = comp1.getTimestamp() - trace2.getTimestamp();
 
         assertEquals(latency, details.getLatency());
-        assertTrue(details.hasProperty("prop1"));
-        assertTrue(details.hasProperty("prop2"));
         assertEquals(trace1.getFragmentId(), details.getSourceFragmentId());
-        assertEquals("host1", details.getSourceHostName());
-        assertEquals("addr1", details.getSourceHostAddress());
         assertEquals(trace2.getFragmentId(), details.getTargetFragmentId());
-        assertEquals("host2", details.getTargetHostName());
-        assertEquals("addr2", details.getTargetHostAddress());
-        assertEquals("p1", details.getProperties(Constants.PROP_PRINCIPAL).iterator().next().getValue());
 
         assertEquals(comp1.getTimestamp(), details.getTimestamp());
     }

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriverTest.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/communicationdetails/CommunicationDetailsDeriverTest.java
@@ -59,7 +59,8 @@ public class CommunicationDetailsDeriverTest {
         List<Trace> traces = new ArrayList<Trace>();
 
         Trace trace1 = new Trace();
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("trace1");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()));
 
         traces.add(trace1);
@@ -98,11 +99,9 @@ public class CommunicationDetailsDeriverTest {
         deriver.setSourceInfoCache(cache);
 
         Trace trace1 = new Trace();
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()));
-
-        Component c1 = new Component();
-        trace1.getNodes().add(c1);
 
         Producer p1 = new Producer();
         p1.setUri("p1");
@@ -113,33 +112,15 @@ public class CommunicationDetailsDeriverTest {
         pid1.setValue("pid1");
         p1.getCorrelationIds().add(pid1);
 
-        c1.getNodes().add(p1);
-
-        Producer p2 = new Producer();
-        p2.setUri("p2");
-        p2.setTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()));
-
-        CorrelationIdentifier pid2 = new CorrelationIdentifier();
-        pid2.setScope(Scope.Interaction);
-        pid2.setValue("pid2");
-        p2.getCorrelationIds().add(pid2);
-
-        c1.getNodes().add(p2);
+        trace1.getNodes().add(p1);
 
         deriver.initialise(null, Collections.singletonList(trace1));
 
         SourceInfo si1 = deriver.getSourceInfoCache().get(null, "pid1");
-        SourceInfo si2 = deriver.getSourceInfoCache().get(null, "pid2");
 
         assertNotNull(si1);
-        assertNotNull(si2);
 
         assertEquals(EndpointUtil.encodeClientURI("p1"), si1.getEndpoint().getUri());
-
-        // Check that source info 2 has same origin URI as p1, as they
-        // are from the same fragment (without a consumer) so are being identified
-        // as a client of the first producer URI found (see HWKBTM-353).
-        assertEquals(EndpointUtil.encodeClientURI("p1"), si2.getEndpoint().getUri());
     }
 
     @Test
@@ -150,7 +131,8 @@ public class CommunicationDetailsDeriverTest {
         deriver.setSourceInfoCache(cache);
 
         Trace trace1 = new Trace();
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("trace1");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()));
 
         Consumer c1 = new Consumer();
@@ -239,7 +221,8 @@ public class CommunicationDetailsDeriverTest {
         trace1.setTimestamp(1000000000);
 
         trace1.setTransaction(TXN_NAME);
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setHostName("host1");
         trace1.setHostAddress("addr1");
 
@@ -271,7 +254,8 @@ public class CommunicationDetailsDeriverTest {
         trace2.setTimestamp(2000000000);
 
         trace2.setTransaction(TXN_NAME);
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("def");
         trace2.setHostName("host2");
         trace2.setHostAddress("addr2");
 
@@ -307,10 +291,10 @@ public class CommunicationDetailsDeriverTest {
         assertEquals(400000, details.getLatency());
         assertTrue(details.hasProperty("prop1"));
         assertTrue(details.hasProperty("prop2"));
-        assertEquals("trace1", details.getSourceFragmentId());
+        assertEquals(trace1.getFragmentId(), details.getSourceFragmentId());
         assertEquals("host1", details.getSourceHostName());
         assertEquals("addr1", details.getSourceHostAddress());
-        assertEquals("trace2", details.getTargetFragmentId());
+        assertEquals(trace2.getFragmentId(), details.getTargetFragmentId());
         assertEquals("host2", details.getTargetHostName());
         assertEquals("addr2", details.getTargetHostAddress());
         assertEquals("p1", details.getProperties(Constants.PROP_PRINCIPAL).iterator().next().getValue());
@@ -333,7 +317,8 @@ public class CommunicationDetailsDeriverTest {
         trace1.setTimestamp(1000000000);
 
         trace1.setTransaction(TXN_NAME);
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setHostName("host1");
         trace1.setHostAddress("addr1");
 
@@ -365,7 +350,8 @@ public class CommunicationDetailsDeriverTest {
         trace2.setTimestamp(2000000000);
 
         trace2.setTransaction(TXN_NAME);
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("def");
         trace2.setHostName("host2");
         trace2.setHostAddress("addr2");
 
@@ -401,10 +387,10 @@ public class CommunicationDetailsDeriverTest {
         assertEquals(400000, details.getLatency());
         assertTrue(details.hasProperty("prop1"));
         assertTrue(details.hasProperty("prop2"));
-        assertEquals("trace1", details.getSourceFragmentId());
+        assertEquals(trace1.getFragmentId(), details.getSourceFragmentId());
         assertEquals("host1", details.getSourceHostName());
         assertEquals("addr1", details.getSourceHostAddress());
-        assertEquals("trace2", details.getTargetFragmentId());
+        assertEquals(trace2.getFragmentId(), details.getTargetFragmentId());
         assertEquals("host2", details.getTargetHostName());
         assertEquals("addr2", details.getTargetHostAddress());
         assertEquals("p1", details.getProperties(Constants.PROP_PRINCIPAL).iterator().next().getValue());
@@ -431,7 +417,8 @@ public class CommunicationDetailsDeriverTest {
         traces1.add(trace1);
 
         trace1.setTransaction(TXN_NAME);
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setHostName("host1");
         trace1.setHostAddress("addr1");
 
@@ -466,7 +453,8 @@ public class CommunicationDetailsDeriverTest {
         traces2.add(trace2);
 
         trace2.setTransaction(TXN_NAME);
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("def");
         trace2.setHostName("host2");
         trace2.setHostAddress("addr2");
 
@@ -507,7 +495,8 @@ public class CommunicationDetailsDeriverTest {
         traces1.add(trace1);
 
         trace1.setTransaction(TXN_NAME);
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setHostName("host1");
         trace1.setHostAddress("addr1");
 
@@ -542,7 +531,8 @@ public class CommunicationDetailsDeriverTest {
         traces2.add(trace2);
 
         trace2.setTransaction(TXN_NAME);
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("def");
         trace2.setHostName("host2");
         trace2.setHostAddress("addr2");
 
@@ -578,12 +568,14 @@ public class CommunicationDetailsDeriverTest {
         List<Trace> traces1 = new ArrayList<Trace>();
 
         Trace trace1 = new Trace();
+        trace1.setTraceId("1");
         trace1.setTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()));
 
         traces1.add(trace1);
 
         trace1.setTransaction(TXN_NAME);
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("1");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setHostName("host1");
         trace1.setHostAddress("addr1");
 
@@ -606,7 +598,8 @@ public class CommunicationDetailsDeriverTest {
         traces2.add(trace2);
 
         trace2.setTransaction(TXN_NAME);
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("2");
         trace2.setHostName("host2");
         trace2.setHostAddress("addr2");
 
@@ -637,10 +630,10 @@ public class CommunicationDetailsDeriverTest {
         assertTrue(p1.getDuration() == details.getProducerDuration());
         assertEquals(400000, details.getLatency());
         assertTrue(details.hasProperty("prop1"));
-        assertEquals("trace1", details.getSourceFragmentId());
+        assertEquals(trace1.getFragmentId(), details.getSourceFragmentId());
         assertEquals("host1", details.getSourceHostName());
         assertEquals("addr1", details.getSourceHostAddress());
-        assertEquals("trace2", details.getTargetFragmentId());
+        assertEquals(trace2.getFragmentId(), details.getTargetFragmentId());
         assertEquals("host2", details.getTargetHostName());
         assertEquals("addr2", details.getTargetHostAddress());
         assertEquals("p1", details.getProperties(Constants.PROP_PRINCIPAL).iterator().next().getValue());
@@ -661,7 +654,8 @@ public class CommunicationDetailsDeriverTest {
         traces1.add(trace1);
 
         trace1.setTransaction(TXN_NAME);
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
 
         Consumer c1 = new Consumer();
         c1.setUri("FirstURI");
@@ -693,7 +687,8 @@ public class CommunicationDetailsDeriverTest {
 
         traces2.add(trace2);
 
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("def");
 
         Consumer c2 = new Consumer();
         c2.setUri("SecondURI");
@@ -736,7 +731,8 @@ public class CommunicationDetailsDeriverTest {
         trace1.setTimestamp(1000000);
 
         trace1.setTransaction(TXN_NAME);
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setHostName("host1");
         trace1.setHostAddress("addr1");
 
@@ -763,7 +759,8 @@ public class CommunicationDetailsDeriverTest {
         trace2.setTimestamp(2000000);
 
         trace2.setTransaction(TXN_NAME);
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("def");
         trace2.setHostName("host2");
         trace2.setHostAddress("addr2");
 
@@ -776,7 +773,7 @@ public class CommunicationDetailsDeriverTest {
 
         CorrelationIdentifier cid2 = new CorrelationIdentifier();
         cid2.setScope(Scope.CausedBy);
-        cid2.setValue("trace1:0:0");
+        cid2.setValue("abc:0:0");
         c2.getCorrelationIds().add(cid2);
 
         trace2.getNodes().add(c2);
@@ -801,10 +798,10 @@ public class CommunicationDetailsDeriverTest {
         assertEquals(latency, details.getLatency());
         assertTrue(details.hasProperty("prop1"));
         assertTrue(details.hasProperty("prop2"));
-        assertEquals("trace1", details.getSourceFragmentId());
+        assertEquals(trace1.getFragmentId(), details.getSourceFragmentId());
         assertEquals("host1", details.getSourceHostName());
         assertEquals("addr1", details.getSourceHostAddress());
-        assertEquals("trace2", details.getTargetFragmentId());
+        assertEquals(trace2.getFragmentId(), details.getTargetFragmentId());
         assertEquals("host2", details.getTargetHostName());
         assertEquals("addr2", details.getTargetHostAddress());
         assertEquals("p1", details.getProperties(Constants.PROP_PRINCIPAL).iterator().next().getValue());
@@ -820,7 +817,8 @@ public class CommunicationDetailsDeriverTest {
         deriver.setSourceInfoCache(cache);
 
         Trace trace1 = new Trace();
-        trace1.setFragmentId("trace1");
+        trace1.setTraceId("abc");
+        trace1.setFragmentId(trace1.getTraceId());
         trace1.setTimestamp(1000000000);
 
         Consumer c1 = new Consumer();
@@ -840,7 +838,8 @@ public class CommunicationDetailsDeriverTest {
         c1.getNodes().add(p1a);
 
         Trace trace2 = new Trace();
-        trace2.setFragmentId("trace2");
+        trace2.setTraceId(trace1.getTraceId());
+        trace2.setFragmentId("def");
         trace2.setTimestamp(2000000000);
 
         Consumer c2 = new Consumer();
@@ -884,10 +883,10 @@ public class CommunicationDetailsDeriverTest {
         assertNotNull(details);
 
         assertEquals(5, details.getOutbound().size());
-        assertTrue(details.getOutbound().get(0).getLinkIds().contains("trace2:0"));
-        assertTrue(details.getOutbound().get(1).getLinkIds().contains("trace2:0:0"));
+        assertTrue(details.getOutbound().get(0).getLinkIds().contains("def:0"));
+        assertTrue(details.getOutbound().get(1).getLinkIds().contains("def:0:0"));
         assertTrue(details.getOutbound().get(2).getLinkIds().contains("pid2"));
-        assertTrue(details.getOutbound().get(3).getLinkIds().contains("trace2:0:1"));
+        assertTrue(details.getOutbound().get(3).getLinkIds().contains("def:0:1"));
         assertTrue(details.getOutbound().get(4).getLinkIds().contains("pid3"));
         assertTrue(details.getOutbound().get(0).isMultiConsumer());
         assertTrue(details.getOutbound().get(1).isMultiConsumer());

--- a/server/processors/src/test/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiatorTest.java
+++ b/server/processors/src/test/java/org/hawkular/apm/server/processor/tracecompletiontime/TraceCompletionInformationInitiatorTest.java
@@ -95,6 +95,29 @@ public class TraceCompletionInformationInitiatorTest {
     }
 
     @Test
+    public void testProcessSingleInitialFragmentProducer() throws RetryAttemptException {
+        Trace trace = new Trace();
+        trace.setTraceId("traceId");
+        trace.setFragmentId(trace.getTraceId());
+
+        Producer p = new Producer();
+        p.setUri("uri");
+        p.addInteractionCorrelationId("pid");
+
+        trace.getNodes().add(p);
+
+        TraceCompletionInformationInitiator initiator = new TraceCompletionInformationInitiator();
+
+        TraceCompletionInformation ci = initiator.processOneToOne(null, trace);
+
+        assertNotNull(ci);
+        assertEquals(2, ci.getCommunications().size());
+        assertTrue(ci.getCommunications().get(0).getIds().contains("traceId:0"));
+        assertTrue(ci.getCommunications().get(1).getIds().contains("pid"));
+        assertEquals(EndpointUtil.encodeClientURI(p.getUri()), ci.getCompletionTime().getUri());
+    }
+
+    @Test
     public void testProcessSingleInitialFragmentComponent() throws RetryAttemptException {
         Trace trace = new Trace();
         trace.setTraceId("traceId");
@@ -121,7 +144,7 @@ public class TraceCompletionInformationInitiatorTest {
         assertEquals(trace.getTraceId(), ci.getCompletionTime().getId());
         assertEquals(trace.getTransaction(), ci.getCompletionTime().getTransaction());
         assertEquals(trace.getTimestamp(), ci.getCompletionTime().getTimestamp());
-        assertEquals(EndpointUtil.encodeClientURI(c.getUri()), ci.getCompletionTime().getUri());
+        assertEquals(c.getUri(), ci.getCompletionTime().getUri());
         assertEquals(200000, ci.getCompletionTime().getDuration());
         assertEquals(c.getProperties(Constants.PROP_FAULT), ci.getCompletionTime().getProperties(Constants.PROP_FAULT));
         assertEquals(1, ci.getCompletionTime().getProperties(Constants.PROP_FAULT).size());


### PR DESCRIPTION
…ly contains single top level Producer node, to distinguish it from the endpoint used for the server.