### PR TITLE
HWKAPM-721 : Show severity in Instance Details Diagram

### DIFF
--- a/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
+++ b/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
@@ -37,6 +37,9 @@ module InstanceViewDiagram {
 
     private doLink(scope, elm, attrs, ctrl, $compile, hkDurationFilter): void {
 
+      // Severity strip width (must be pair)
+      let stripeWidth = 12;
+
       // Set up zoom support
       let svg = d3.select('svg#idetails'),
         inner = svg.select('g'),
@@ -51,14 +54,18 @@ module InstanceViewDiagram {
       render.shapes().producer = function(parent, bbox, node) {
         let w = bbox.width + 10,
             h = bbox.height + 10,
-            points = [
-              { x:     0,      y:     0 },
-              { x:     w,      y:     0 },
-              { x:     w + 10, y:     -h / 2 },
-              { x:     w,      y:     -h },
-              { x:     0,      y:     -h },
-              { x:     0,      y:     0 }
-            ];
+            points = [{ x: 0, y: 0 }];
+            for (let i = 0; i < stripeWidth; i++) {
+              points.push({'x': i, y: (i % 2 === 0 ? 0 : -h)});
+              points.push({'x': i, y: (i % 2 !== 0 ? 0 : -h)});
+            }
+            points = points.concat([
+              { x: w,      y: 0 },
+              { x: w + 10, y: -h / 2 },
+              { x: w,      y: -h },
+              { x: 0,      y: -h },
+              { x: 0,      y: 0 }
+            ]);
             let shapeSvg = parent.insert('polygon', ':first-child')
               .attr('points', points.map(function(d) { return d.x + ',' + d.y; }).join(' '))
               .attr('transform', 'translate(' + (-w / 1.85) + ',' + (h * 4 / 8) + ')');
@@ -73,14 +80,17 @@ module InstanceViewDiagram {
       render.shapes().consumer = function(parent, bbox, node) {
         let w = bbox.width + 20,
             h = bbox.height + 10,
-            points = [
-              { x:     0, y:          0 },
-              { x:     w, y:          0 },
-              { x:     w, y:          -h },
-              { x:     0, y:          -h },
-              { x:     10, y:         -h / 2 },
-              { x:     0, y:          0 }
-            ];
+            points = [{ x: 0, y: 0 }];
+            for (let i = 0; i < stripeWidth + 1; i++) {
+              points.push({'x': i, y: (i % 2 === 0 ? 0 : -h)});
+              points.push({'x': i + 10, y: -h / 2});
+              points.push({'x': i, y: (i % 2 !== 0 ? 0 : -h)});
+            }
+            points = points.concat([
+              { x:  w, y: -h },
+              { x:  w, y: 0 },
+              { x: 10, y: 0 },
+            ]);
             let shapeSvg = parent.insert('polygon', ':first-child')
               .attr('points', points.map(function(d) { return d.x + ',' + d.y; }).join(' '))
               .attr('transform', 'translate(' + (-w / 2.15) + ',' + (h * 4 / 8) + ')');
@@ -95,15 +105,20 @@ module InstanceViewDiagram {
       render.shapes().component = function(parent, bbox, node) {
         let w = bbox.width + 20,
             h = bbox.height + 8,
-            points = [
-              { x:     -10,    y:     -h / 2 },
-              { x:     0,      y:     -h },
-              { x:     w - 10, y:     -h },
-              { x:     w,      y:     -h / 2 },
-              { x:     w - 10, y:     0 },
-              { x:     0,      y:     0 },
-              { x:     -10,    y:     -h / 2 }
-            ];
+            points = [];
+            for (let i = stripeWidth; i >= 0; i--) {
+              points.push({'x': i, y: (i % 2 === 0 ? 0 : -h)});
+              points.push({'x': i - stripeWidth, y: -h / 2});
+              points.push({'x': i, y: (i % 2 !== 0 ? 0 : -h)});
+            }
+            points = points.concat([
+              { x: 10,     y: -h  },
+              { x: w - 10, y: -h },
+              { x: w,      y: -h / 2 },
+              { x: w - 10, y: 0 },
+              { x: 10,     y: 0 },
+              { x: 0,      y: -h / 2 }
+            ]);
             let shapeSvg = parent.insert('polygon', ':first-child')
               .attr('points', points.map(function(d) { return d.x + ',' + d.y; }).join(' '))
               .attr('transform', 'translate(' + (-w / 2.1) + ',' + (h * 4 / 8) + ')');
@@ -175,7 +190,7 @@ module InstanceViewDiagram {
 
           let uri = (d.uri || '') + (d.operation ? ('[' + d.operation + ']') : '');
 
-          let label = '<span class="name service-name">' + (serviceName || '') + '</span>';
+          let label = '<span class="name service-name">' + (serviceName || '&nbsp;') + '</span>';
           label += '<div class="name">' + uri + '</div>';
 
           let nodeTT = '<ul>';
@@ -186,8 +201,8 @@ module InstanceViewDiagram {
           });
           nodeTT += '</ul>';
 
-          let html = '<div' + ((nodeTT.length > 9) ? (' tooltip-append-to-body="true" tooltip-class="graph-tooltip"' +
-            'tooltip-html-unsafe="' + nodeTT + '"') : '') + '>';
+          let html = '<div class="node-label"' + ((nodeTT.length > 9) ? (' tooltip-append-to-body="true" ' +
+            'tooltip-class="graph-tooltip" tooltip-html-unsafe="' + nodeTT + '"') : '') + '>';
           if (theShape === 'circle') {
             label = '<div><i class="fa fa-share-alt spawn"></i></div>';
           } else {
@@ -212,7 +227,7 @@ module InstanceViewDiagram {
             shape: theShape,
             labelType: 'html',
             label: html,
-            class: 'entity ' + theShape,
+            class: 'entity severity' + d.severity + ' ' + theShape,
             rx: 5,
             ry: 5,
             padding: 0

--- a/ui/src/main/scripts/plugins/e2e/less/e2e.less
+++ b/ui/src/main/scripts/plugins/e2e/less/e2e.less
@@ -210,19 +210,33 @@ th {
     }
     .entity {
         stroke-width: 1.5px;
-        stroke: #bbb;
+        fill: #72767B;
+    }
+    .entity .node-label {
+        margin-left: 1.5em;
+    }
+    .entity.circle .node-label {
+        margin-left: 0;
+    }
+    .entity.producer .node-label {
+        margin-left: 1.0em;
     }
     .entity.consumer {
-        fill: #6e929a;
         .duration {
-            margin-left: 1.5em;
+            margin-left: 0.5em;
         }
     }
-    .entity.producer {
-        fill: #af9c3e;
+    .entity.severity0 {
+        stroke: #6ec664;
     }
-    .entity.component {
-        fill: #9a6e6e;
+    .entity.severity1 {
+        stroke: #f0ab00;
+    }
+    .entity.severity2 {
+        stroke: #ec7a08;
+    }
+    .entity.severity3 {
+        stroke: #cc0000;
     }
     i.spawn {
         color: #ddd;

--- a/ui/src/main/scripts/plugins/e2e/less/e2e.less
+++ b/ui/src/main/scripts/plugins/e2e/less/e2e.less
@@ -236,6 +236,9 @@ th {
         stroke: #ec7a08;
     }
     .entity.severity3 {
+        stroke: #b35c00;
+    }
+    .entity.severity4 {
         stroke: #cc0000;
     }
     i.spawn {

--- a/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
+++ b/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
@@ -191,11 +191,13 @@ module E2E {
       let calcSeverity = function(nodes, maxDuration) {
         _.forEach(nodes, (node: any) => {
           let percentage = node.duration / maxDuration;
-          if (percentage >= 0.9) {
+          if (percentage >= 0.8) {
+            node.severity = 4;
+          } else if (percentage >= 0.6) {
             node.severity = 3;
-          } else if (percentage >= 0.7) {
+          } else if (percentage >= 0.4) {
             node.severity = 2;
-          } else if (percentage >= 0.5) {
+          } else if (percentage >= 0.2) {
             node.severity = 1;
           } else {
             node.severity = 0;

--- a/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
+++ b/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
@@ -178,11 +178,40 @@ module E2E {
       // Pagination
       $scope.numPerPage = 15;
 
+      let getMaxDuration = function(nodes, maxDuration) {
+        _.forEach(nodes, (node: any) => {
+          maxDuration = node.duration > maxDuration ? node.duration : maxDuration;
+          if(node.nodes && node.nodes.length > 0) {
+            maxDuration = getMaxDuration(node.nodes, maxDuration);
+          }
+        });
+        return maxDuration;
+      };
+
+      let calcSeverity = function(nodes, maxDuration) {
+        _.forEach(nodes, (node: any) => {
+          let percentage = node.duration / maxDuration;
+          if (percentage >= 0.9) {
+            node.severity = 3;
+          } else if (percentage >= 0.7) {
+            node.severity = 2;
+          } else if (percentage >= 0.5) {
+            node.severity = 1;
+          } else {
+            node.severity = 0;
+          }
+          if(node.nodes && node.nodes.length > 0) {
+            calcSeverity(node.nodes, maxDuration);
+          }
+        });
+      };
+
       $scope.showIVD = function(txId) {
         if ($scope.selectedTx === txId) {
           $scope.selectedTx = '';
         } else {
           $http.get('/hawkular/apm/traces/complete/' + txId).then(function(resp) {
+            calcSeverity(resp.data.nodes, getMaxDuration(resp.data.nodes, 0));
             $scope.instDetails = resp.data.nodes;
             $scope.selectedTx = txId;
           });


### PR DESCRIPTION
Some limitations, so the border needs to be in the same color as the severity stripe.

Currently green (severity 0) is for 0-50% of highest duration, gold (severity 1) is for 50%-70%, orange (severity 2) is for 70%-90% and red (severity 3) is for 90-100%.

Some samples:

![image](https://cloud.githubusercontent.com/assets/1737954/21068315/1468ee5c-be69-11e6-85b1-2f9185caa8f4.png)

![image](https://cloud.githubusercontent.com/assets/1737954/21068319/1b4a9e0a-be69-11e6-9396-36ff059be726.png)
