### PR TITLE
HWKAPM-785 : Highlight Instance nodes with faults

### DIFF
--- a/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
+++ b/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
@@ -194,9 +194,13 @@ module InstanceViewDiagram {
           label += '<div class="name">' + uri + '</div>';
 
           let nodeTT = '<ul>';
+          let hasFault = false;
           _.each(d.properties, (property) => {
             if (!!property.value) {
               nodeTT += ('<li class=\'tt-prop\'><strong>' + property.name + '</strong> ' + property.value + '</li>');
+              if (property.name === 'fault') {
+                hasFault = true;
+              }
             }
           });
           nodeTT += '</ul>';
@@ -212,6 +216,11 @@ module InstanceViewDiagram {
             label += '    ' + hkDurationFilter(d.duration);
             label += '  </span>';
             label += '</span>';
+            if (hasFault) {
+              label += '<span class="pull-right fault-indicator">';
+              label += '  <i class="fa fa-warning"></i>';
+              label += '</span>';
+            }
           }
           label += '</div>';
           html += label;

--- a/ui/src/main/scripts/plugins/e2e/less/e2e.less
+++ b/ui/src/main/scripts/plugins/e2e/less/e2e.less
@@ -149,6 +149,9 @@ th {
     }
     .fault-indicator {
         margin-top: 6px;
+        i {
+            color: #fafafa;
+        }
     }
     // .node g div {
     //     width: 200px;

--- a/ui/src/main/scripts/plugins/e2e/less/e2e.less
+++ b/ui/src/main/scripts/plugins/e2e/less/e2e.less
@@ -147,6 +147,9 @@ th {
         margin-top: 5px;
         color: #d6d6d6;
     }
+    .fault-indicator {
+        margin-top: 6px;
+    }
     // .node g div {
     //     width: 200px;
     //     height: 40px;
@@ -224,6 +227,9 @@ th {
     .entity.consumer {
         .duration {
             margin-left: 0.5em;
+        }
+        .fault-indicator {
+            width: 4%;
         }
     }
     .entity.severity0 {


### PR DESCRIPTION
Show a warning sign on the bottom right for nodes that have a fault property.

![image](https://cloud.githubusercontent.com/assets/1737954/21368406/7164d7e4-c6fa-11e6-89c4-d8f0eeced015.png)

(Sample image has all nodes with the marker, for viewing how it looks in the different node types)