### PR TITLE
HWKAPM-802 | Docker images need to be cleaned up after jenkins CI run

### DIFF
--- a/tests/app/polyglot-opentracing/docker-compose.yml
+++ b/tests/app/polyglot-opentracing/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ version: "2"
 
 services:
   wildfly-swarm:
-    image: hawkular/apm-tests-app-polyglot-opentracing-java
+    build: java
   nodejs:
     build: js
     ports:

--- a/tests/app/polyglot-opentracing/java/Dockerfile
+++ b/tests/app/polyglot-opentracing/java/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,7 @@ MAINTAINER Pavol Loffay <ploffay@redhat.com>
 
 ENV APP_HOME /app/
 
-COPY hawkular-apm-tests-app-polyglot-opentracing-swarm.jar $APP_HOME
+COPY target/hawkular-apm-tests-app-polyglot-opentracing-swarm.jar $APP_HOME
 
 WORKDIR $APP_HOME
 

--- a/tests/app/polyglot-opentracing/java/pom.xml
+++ b/tests/app/polyglot-opentracing/java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,37 +91,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>itest</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-                <phase>install</phase>
-              </execution>
-            </executions>
-            <configuration>
-              <imageName>hawkular/apm-tests-app-polyglot-opentracing-java</imageName>
-              <dockerDirectory>${project.basedir}/docker</dockerDirectory>
-              <resources>
-                <resource>
-                  <targetPath>/</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>${project.artifactId}-swarm.jar</include>
-                </resource>
-              </resources>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/DockerComposeExecutor.java
+++ b/tests/instrumentation-framework/src/main/java/org/hawkular/apm/tests/dockerized/environment/DockerComposeExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.apm.tests.dockerized.environment;
 
 import java.io.BufferedReader;
@@ -75,7 +74,7 @@ public class DockerComposeExecutor extends AbstractDockerBasedEnvironment {
     @Override
     public void stopAndRemove(List<String> ids) {
         List<String> cmd = composeCommandWithFiles(ids);
-        cmd.addAll(Arrays.asList("down", "--rmi", "local"));
+        cmd.addAll(Arrays.asList("down", "--rmi", "all"));
         try {
             runShellCommand(cmd);
         } catch (EnvironmentException ex) {


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-802

It does not clean base images as java,node. Everything else is removed.

Review notes:
1. `docker rmi -f $(dokcer images -q)`
2. `mvn clean install -Pitest -fn`
3. `docker images` -> It should list only `openjdk` and `node`

run 2. and 3. again it should always show the same images.