### PR TITLE
HWKAPM-815 | Do not publish test and example artifacts to maven

### DIFF
--- a/examples/vertx-opentracing/pom.xml
+++ b/examples/vertx-opentracing/pom.xml
@@ -62,4 +62,16 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/performance/server/pom.xml
+++ b/performance/server/pom.xml
@@ -82,6 +82,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -44,6 +44,16 @@
   </modules>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-815

maven-deploy-plugin should prevent publishing unnecessary artifacts to maven central repo.