### PR TITLE
HWKAPM-811 Store HTTP status code in OpenTracing standard tag 'http.s…

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/model/Constants.java
+++ b/api/src/main/java/org/hawkular/apm/api/model/Constants.java
@@ -60,16 +60,14 @@ public class Constants {
     public static final String PROP_PRINCIPAL = "principal";
 
     /**
-     * Property key representing the fault
+     * Property key representing the fault. A 'fault' will represent
+     * the non-normal result of a call to a business service. For example,
+     * if requesting a user's account, then a fault may be "Account Not Found".
+     * Communication protocol errors will be recorded in protocol specific
+     * tags, such as "http.status_code".
      * {@link org.hawkular.apm.api.model.Property#name}
      */
     public static final String PROP_FAULT = "fault";
-
-    /**
-     * Property key representing the fault code
-     * {@link org.hawkular.apm.api.model.Property#name}
-     */
-    public static final String PROP_FAULT_CODE = "fault.code";
 
     /**
      * Property key representing the database statement

--- a/client/agent-opentracing/src/main/resources/apmrules/java/apm-java-net.btm
+++ b/client/agent-opentracing/src/main/resources/apmrules/java/apm-java-net.btm
@@ -55,8 +55,7 @@ HELPER org.hawkular.apm.agent.opentracing.OpenTracingManager
 AT EXCEPTION EXIT
 IF hasSpanWithId(String.valueOf($0.hashCode())) && includePath($0.getURL().getPath()) && !callerMatches("HttpURLConnection.*",true)
 DO
-  getSpan().setTag("fault.code", String.valueOf($0.responseCode))
-    .setTag("fault", $0.responseMessage);
+  getSpan().setTag("http.status_code", String.valueOf($0.responseCode));
   finishSpan();
 ENDRULE
 
@@ -69,8 +68,7 @@ AT EXIT
 IF hasSpanWithId(String.valueOf($0.hashCode())) && includePath($0.getURL().getPath()) && !callerMatches("HttpURLConnection.*",true)
 		&& $0.responseCode >= 400
 DO
-  getSpan().setTag("fault.code", String.valueOf($0.responseCode))
-    .setTag("fault", $0.responseMessage);
+  getSpan().setTag("http.status_code", String.valueOf($0.responseCode));
 ENDRULE
 
 RULE java.net(6) Java HttpUrlConnection getResponseCode End

--- a/client/agent-opentracing/src/main/resources/apmrules/javax/apm-javax-servlet.btm
+++ b/client/agent-opentracing/src/main/resources/apmrules/javax/apm-javax-servlet.btm
@@ -24,8 +24,7 @@ HELPER org.hawkular.apm.agent.opentracing.OpenTracingManager
 AT ENTRY
 IF hasSpan()
 DO
-  getSpan().setTag("fault.code",String.valueOf($1))
-    .setTag("fault",String.valueOf($1));
+  getSpan().setTag("http.status_code",String.valueOf($1));
 ENDRULE
 
 RULE javax.servlet(3) Javax Servlet Consumer End Sync Fault Code Message
@@ -35,8 +34,7 @@ HELPER org.hawkular.apm.agent.opentracing.OpenTracingManager
 AT ENTRY
 IF hasSpan()
 DO
-  getSpan().setTag("fault.code",String.valueOf($1))
-    .setTag("fault",$2);
+  getSpan().setTag("http.status_code",String.valueOf($1));
 ENDRULE
 
 RULE javax.servlet(4) Javax Servlet Consumer End Sync

--- a/client/agent-opentracing/src/main/resources/apmrules/org/apache/apm-apache-http-client.btm
+++ b/client/agent-opentracing/src/main/resources/apmrules/org/apache/apm-apache-http-client.btm
@@ -23,8 +23,7 @@ HELPER org.hawkular.apm.agent.opentracing.OpenTracingManager
 AT EXIT
 IF hasSpan() && $!.getStatusLine().getStatusCode() >= 400
 DO
-  getSpan().setTag("fault.code",String.valueOf($!.getStatusLine().getStatusCode()))
-	.setTag("fault",$!.getStatusLine().getReasonPhrase());
+  getSpan().setTag("http.status_code",String.valueOf($!.getStatusLine().getStatusCode()));
 ENDRULE
 
 RULE org.apache.http.client(3) Apache HttpClient Producer Sync Response

--- a/client/instrumentation-jvm/src/main/resources/apmconfig/jvm/java/apm-java-net.json
+++ b/client/instrumentation-jvm/src/main/resources/apmconfig/jvm/java/apm-java-net.json
@@ -261,12 +261,8 @@
         "condition": "isActive() && $! >= 400",
         "actions": [{
           "type": "SetProperty",
-          "name": "fault.code",
+          "name": "http.status_code",
           "valueExpression": "$!"
-        },{
-          "type": "SetProperty",
-          "name": "fault",
-          "valueExpression": "$0.responseMessage"
         },{
           "type": "InstrumentProducer",
           "direction": "Out",

--- a/client/instrumentation-jvm/src/main/resources/apmconfig/jvm/org/apache/apm-org-apache-httpclient.json
+++ b/client/instrumentation-jvm/src/main/resources/apmconfig/jvm/org/apache/apm-org-apache-httpclient.json
@@ -102,12 +102,8 @@
         "condition": "isActive() && $1.getStatusCode() >= 400",
         "actions": [{
           "type": "SetProperty",
-          "name": "fault.code",
+          "name": "http.status_code",
           "valueExpression": "$1.getStatusCode()"
-        },{
-          "type": "SetProperty",
-          "name": "fault",
-          "valueExpression": "$1.getReasonPhrase()"
         }]
       },{
         "ruleName": "Apache HttpClient Producer Check Fault Or No Content End",

--- a/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/client/http/ApacheHttpClientITest.java
+++ b/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/client/http/ApacheHttpClientITest.java
@@ -43,6 +43,8 @@ import org.hawkular.apm.api.utils.NodeUtil;
 import org.hawkular.apm.tests.common.Wait;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -162,8 +164,7 @@ public class ApacheHttpClientITest extends AbstractBaseHttpITest {
         }
 
         if (fault) {
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         }
     }

--- a/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/client/http/JBossRESTEasyClientITest.java
+++ b/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/client/http/JBossRESTEasyClientITest.java
@@ -33,6 +33,8 @@ import org.hawkular.apm.api.utils.NodeUtil;
 import org.hawkular.apm.tests.common.Wait;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -150,8 +152,7 @@ public class JBossRESTEasyClientITest extends AbstractBaseHttpITest {
         }
 
         if (fault) {
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         }
     }

--- a/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/client/http/JavaHttpURLConnectionClientITest.java
+++ b/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/client/http/JavaHttpURLConnectionClientITest.java
@@ -33,6 +33,8 @@ import org.hawkular.apm.api.utils.NodeUtil;
 import org.hawkular.apm.tests.common.Wait;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -199,8 +201,7 @@ public class JavaHttpURLConnectionClientITest extends AbstractBaseHttpITest {
         }
 
         if (fault) {
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         }
     }

--- a/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/server/http/JavaxServletAsyncServerITest.java
+++ b/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/server/http/JavaxServletAsyncServerITest.java
@@ -46,6 +46,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -205,9 +207,8 @@ public class JavaxServletAsyncServerITest extends ClientTestBase {
         assertEquals(method, testConsumer.getOperation());
 
         if (fault) {
-            assertEquals("Unauthorized", testConsumer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("401",
-                    testConsumer.getProperties(Constants.PROP_FAULT_CODE).iterator().next().getValue());
+                    testConsumer.getProperties(Tags.HTTP_STATUS.getKey()).iterator().next().getValue());
         }
     }
 

--- a/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/server/http/JavaxServletSyncServerITest.java
+++ b/tests/agent-opentracing/src/test/java/org/hawkular/apm/tests/agent/opentracing/server/http/JavaxServletSyncServerITest.java
@@ -53,6 +53,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -243,9 +245,8 @@ public class JavaxServletSyncServerITest extends ClientTestBase {
         assertEquals(method, testConsumer.getOperation());
 
         if (fault) {
-            assertEquals("Unauthorized", testConsumer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
             assertEquals("401",
-                    testConsumer.getProperties(Constants.PROP_FAULT_CODE).iterator().next().getValue());
+                    testConsumer.getProperties(Tags.HTTP_STATUS.getKey()).iterator().next().getValue());
         }
     }
 

--- a/tests/container/jetty/pom.xml
+++ b/tests/container/jetty/pom.xml
@@ -79,6 +79,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterAsyncITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterAsyncITest.java
@@ -49,6 +49,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -249,9 +251,7 @@ public class ClientJettyReaderWriterAsyncITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                                 .iterator().next().getValue());
         } else {
 

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyReaderWriterITest.java
@@ -48,6 +48,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -247,9 +249,7 @@ public class ClientJettyReaderWriterITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         } else {
 

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamAsyncITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamAsyncITest.java
@@ -51,6 +51,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -252,9 +254,7 @@ public class ClientJettyStreamAsyncITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         } else {
 

--- a/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamITest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/apm/tests/client/jetty/ClientJettyStreamITest.java
@@ -59,6 +59,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
+
 /**
  * @author gbrown
  */
@@ -320,9 +322,7 @@ public class ClientJettyStreamITest extends ClientTestBase {
                 testConsumer.getIn().getHeaders().containsKey(TEST_HEADER));
 
         if (fault) {
-            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         } else {
 

--- a/tests/instrumentation/pom.xml
+++ b/tests/instrumentation/pom.xml
@@ -132,6 +132,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/ApacheHttpClientITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/ApacheHttpClientITest.java
@@ -49,6 +49,7 @@ import org.hawkular.apm.tests.common.ClientTestBase;
 import org.hawkular.apm.tests.common.Wait;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -210,9 +211,7 @@ public class ApacheHttpClientITest extends ClientTestBase {
         assertFalse("testProducer has no headers", testProducer.getIn().getHeaders().isEmpty());
 
         if (fault) {
-            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         } else {
 

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JBossRESTEasyClientITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JBossRESTEasyClientITest.java
@@ -38,6 +38,7 @@ import org.hawkular.apm.tests.common.ClientTestBase;
 import org.hawkular.apm.tests.common.Wait;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -195,9 +196,7 @@ public class JBossRESTEasyClientITest extends ClientTestBase {
         assertFalse("testProducer has no headers", testProducer.getIn().getHeaders().isEmpty());
 
         if (fault) {
-            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE).iterator().next().getValue());
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey()).iterator().next().getValue());
         } else {
 
             if (isProcessContent()) {

--- a/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JavaNetHttpITest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/apm/tests/client/http/JavaNetHttpITest.java
@@ -41,6 +41,7 @@ import org.hawkular.apm.tests.common.ClientTestBase;
 import org.hawkular.apm.tests.common.Wait;
 import org.junit.Test;
 
+import io.opentracing.tag.Tags;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -289,9 +290,7 @@ public class JavaNetHttpITest extends ClientTestBase {
         assertFalse("testProducer has no headers", testProducer.getIn().getHeaders().isEmpty());
 
         if (fault) {
-            assertEquals(1, testProducer.getProperties(Constants.PROP_FAULT).size());
-            assertEquals("Unauthorized", testProducer.getProperties(Constants.PROP_FAULT).iterator().next().getValue());
-            assertEquals("401", testProducer.getProperties(Constants.PROP_FAULT_CODE)
+            assertEquals("401", testProducer.getProperties(Tags.HTTP_STATUS.getKey())
                     .iterator().next().getValue());
         } else {
 


### PR DESCRIPTION
…tatus_code' and don't use 'fault' tag for communication protocol errors, only business protocol level faults