### PR TITLE
exclude Makefile in maven license-maven-plugin task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -591,6 +591,7 @@
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <excludes combine.children="append">
+            <exclude>Makefile</exclude>
             <exclude>**/*.data</exclude>
             <exclude>**/*.deployed</exclude>
             <exclude>**/.babelrc</exclude>


### PR DESCRIPTION
This allows me to have a local Makefile for building outside of an IDE.