### PR TITLE
dont fail the jvm when one of the btm files is corrupt

### DIFF
--- a/client/agent-opentracing/src/main/java/org/hawkular/apm/agent/opentracing/OpenTracingRuleLoader.java
+++ b/client/agent-opentracing/src/main/java/org/hawkular/apm/agent/opentracing/OpenTracingRuleLoader.java
@@ -70,7 +70,11 @@ public class OpenTracingRuleLoader {
         }
 
         try (PrintWriter writer = new PrintWriter(new StringWriter())) {
-            transformer.installScript(scripts, scriptNames, writer);
+            try {
+                transformer.installScript(scripts, scriptNames, writer);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Failed to install scripts", e);
+            }
         }
 
         if (log.isLoggable(Level.FINE)) {


### PR DESCRIPTION
Without this patch this happens:
```
Starting foo: Exception in thread "main" java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
	at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.byteman.agent.Main.premain(Main.java:287)
	at org.hawkular.apm.agent.opentracing.OpenTracingAgent.premain(OpenTracingAgent.java:33)
	... 6 more
Caused by: java.lang.Exception: org.jboss.byteman.agent.Transformer : invalid text outside of RULE/ENDRULE at line 1 in script /cp/apmrules/bla.btm
	at org.jboss.byteman.agent.ScriptRepository.processScripts(ScriptRepository.java:152)
	at org.jboss.byteman.agent.Retransformer.installScript(Retransformer.java:73)
	at org.hawkular.apm.agent.opentracing.OpenTracingRuleLoader.initialize(OpenTracingRuleLoader.java:73)
	... 12 more
FATAL ERROR in native method: processing of -javaagent failed
```

With the patch you get this:
```
Starting foo: SEVERE: [OpenTracingRuleLoader] [Thread[main,5,main]] Failed to install scripts
java.lang.Exception: org.jboss.byteman.agent.Transformer : invalid text outside of RULE/ENDRULE at line 1 in script /cp/apmrules/bla.btm
	at org.jboss.byteman.agent.ScriptRepository.processScripts(ScriptRepository.java:152)
	at org.jboss.byteman.agent.Retransformer.installScript(Retransformer.java:73)
	at org.hawkular.apm.agent.opentracing.OpenTracingRuleLoader.initialize(OpenTracingRuleLoader.java:74)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.byteman.agent.Main.premain(Main.java:287)
	at org.hawkular.apm.agent.opentracing.OpenTracingAgent.premain(OpenTracingAgent.java:33)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
	at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
```

BTW, this PR is a hack, because the code should attempt to load 1 script at a time, so only the bad script load attempt fails and all valid ones are loaded.