### PR TITLE
allow whitelisting of file extensions for includePath logic

### DIFF
--- a/api/src/main/java/org/hawkular/apm/api/utils/PropertyUtil.java
+++ b/api/src/main/java/org/hawkular/apm/api/utils/PropertyUtil.java
@@ -116,6 +116,11 @@ public class PropertyUtil {
     public static final String HAWKULAR_APM_AGENT_STATE_EXPIRY_INTERVAL = "HAWKULAR_APM_AGENT_STATE_EXPIRY_INTERVAL";
 
     /**
+     * Comma separated list of whitelisted file extensions. All others will be ignored by the agent.
+     */
+    public static final String HAWKULAR_APM_AGENT_FILE_EXTENSION_WHITELIST = "HAWKULAR_APM_AGENT_FILE_EXTENSION_WHITELIST";
+
+    /**
      * The maximum number of retry attempts when processing a batch of events.
      */
     public static final String HAWKULAR_APM_PROCESSOR_MAX_RETRY_COUNT = "HAWKULAR_APM_PROCESSOR_MAX_RETRY_COUNT";

--- a/client/agent-opentracing/src/test/java/org/hawkular/apm/agent/opentracing/OpenTracingManagerTest.java
+++ b/client/agent-opentracing/src/test/java/org/hawkular/apm/agent/opentracing/OpenTracingManagerTest.java
@@ -149,12 +149,26 @@ public class OpenTracingManagerTest {
 
         assertTrue(otm.includePath("/path/to/anything"));
         assertTrue(otm.includePath("/path.to/anything"));
+        assertTrue(otm.includePath("/path.to/anything.jsp"));
         assertTrue(otm.includePath("anything"));
 
         assertFalse(otm.includePath("/hawkular/apm/anything"));
+        assertFalse(otm.includePath("/path.to/anything.xjsp"));
         assertFalse(otm.includePath("myimage.png"));
         assertFalse(otm.includePath("/myimage.png"));
         assertFalse(otm.includePath("/location/myimage.png"));
+    }
+
+    @Test
+    public void testPathIncludeWhitelist() {
+        OpenTracingManager.fileExtensionWhitelist.add("foo");
+
+        OpenTracingManager otm = new OpenTracingManager(null);
+
+        assertTrue(otm.includePath("/quux/test.foo"));
+        assertFalse(otm.includePath("/my/image.bar"));
+
+        OpenTracingManager.fileExtensionWhitelist.clear();
     }
 
 }


### PR DESCRIPTION
primarily made to allow tracing of jsp files - if you think my commit is overengineered I could refactor to a simple `path.endswith(".jsp")` check