### PR TITLE
extra rule for java.net.HttpURLConnection

### DIFF
--- a/client/agent-opentracing/src/main/resources/apmrules/java/apm-java-net.btm
+++ b/client/agent-opentracing/src/main/resources/apmrules/java/apm-java-net.btm
@@ -32,6 +32,24 @@ DO
         new org.hawkular.apm.agent.opentracing.propagation.HttpURLConnectionInjectAdapter($0));
 ENDRULE
 
+# conn.getResponseCode() on an unconnected connection will trigger a getInputStream call
+# which we skip because of the callerMatch. So we need a explicit rule.
+RULE java.net(2a) Java HttpUrlConnection connect Producer Start getResponseCode
+CLASS ^java.net.HttpURLConnection
+METHOD getResponseCode()
+HELPER org.hawkular.apm.agent.opentracing.OpenTracingManager
+AT ENTRY
+# Need to filter out use of HttpURLConnection by APM, and also only use top level calls to the connection
+IF !$0.connected && includePath($0.getURL().getPath()) && !callerMatches("HttpURLConnection.*",true)
+DO
+  startSpanWithParent(getTracer().buildSpan($0.getRequestMethod())
+  		.withTag("http.uri", $0.getURL().getPath())
+  		.withTag("http.query", $0.getURL().getQuery()),
+  		getSpan(), String.valueOf($0.hashCode()));
+  getTracer().inject(getSpan().context(), textMapFormat(),
+        new org.hawkular.apm.agent.opentracing.propagation.HttpURLConnectionInjectAdapter($0));
+ENDRULE
+
 RULE java.net(3) Java HttpUrlConnection connect Producer Start getOutputStream
 CLASS ^java.net.HttpURLConnection
 METHOD getOutputStream()


### PR DESCRIPTION
Needed to make following work:
```
HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
int rc = conn.getResponseCode();
```

It seems calling `getResponseCode()` on an unconnected connection will trigger a `getInputStream()` call, which is currently skipped because of the callerMatch.

Without this extra rule I did not see the `HWK*` request headers in inter-service calls. With the extra rule I see the headers:
```
GET /lala HTTP/1.1
HWKAPMTRACEID: 99cd9347-a56f-4c6e-a31f-fab458afc8ac
HWKAPMID: 28874245-ddf0-462e-855a-482ba861901d
```

(OT: still can't see service 'foo' calling service 'bar' in the 'distributed tracing' view - any suggestions?)