### PR TITLE
Add cache for bower libs and node_packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache:
   directories:
   - $HOME/.m2/repository
   - $HOME/.m2/wrapper
+  - ui/target/gulp-build/libs
+  - ui/target/gulp-build/node_modules
 
 notifications:
   irc:


### PR DESCRIPTION
Based on the build status it looks like sometimes the build will fail with really long time while fetching ui libraries.

This can be avoided by enabling travis cache on libraries
 * Bower's libs (location - `ui/target/gulp-build/libs`)
 * Node modules (location - `ui/target/gulp-build/node_modules`)