### PR TITLE
Register HTTP extractor/injector

### DIFF
--- a/client/opentracing/src/main/java/io/opentracing/impl/AbstractAPMTracer.java
+++ b/client/opentracing/src/main/java/io/opentracing/impl/AbstractAPMTracer.java
@@ -44,12 +44,15 @@ public abstract class AbstractAPMTracer extends AbstractTracer {
     private ContextSampler sampler;
 
     public AbstractAPMTracer() {
-        this.recorder = new BatchTraceRecorder();
+        this(new BatchTraceRecorder(), Sampler.ALWAYS_SAMPLE);
     }
 
     public AbstractAPMTracer(TraceRecorder recorder, Sampler sampler) {
         this.recorder = recorder;
         this.sampler = new ContextSampler(sampler);
+
+        register(Format.Builtin.HTTP_HEADERS, new TextMapExtractorImpl(this));
+        register(Format.Builtin.HTTP_HEADERS, new TextMapInjectorImpl(this));
     }
 
     public void setTraceRecorder(TraceRecorder recorder) {


### PR DESCRIPTION

This enables to use Format.Bultin.HTTP_HEADERS.
Previously only Format.Builtin.TEXT_MAP was registered.

@objectiser could you please review? I will need this for WF fraction. Could we do a micro release? 