### PR TITLE
Fix Bootstrap UI warnings, using uib-* directives

### DIFF
--- a/ui/src/main/scripts/plugins/apm/html/apm.html
+++ b/ui/src/main/scripts/plugins/apm/html/apm.html
@@ -92,12 +92,12 @@
         <tbody>
           <tr dir-paginate="summary in summaries|orderBy:sortKey:reverse|filter:$root.sbFilter.search|itemsPerPage:config.maxRows" ng-class="{'danger': getElapsedPercentage(summary) > 80,'warning': getElapsedPercentage(summary) > 60}" >
             <td scope="row">
-              <progress>
-                <bar type="danger" value="getActualPercentage(summary)">
-                </bar>
-                <bar type="warning" value="getElapsedMinusActualPercentage(summary)">
-                </bar>
-              </progress>
+              <uib-progress>
+                <uib-bar type="danger" value="getActualPercentage(summary)">
+                </uib-bar>
+                <uib-bar type="warning" value="getElapsedMinusActualPercentage(summary)">
+                </uib-bar>
+              </uib-progress>
             </td>
             <td scope="row">{{ summary.actual | hkDuration }}</td>
             <td scope="row">{{ summary.elapsed | hkDuration }}</td>

--- a/ui/src/main/scripts/plugins/btm/html/btm.html
+++ b/ui/src/main/scripts/plugins/btm/html/btm.html
@@ -76,11 +76,11 @@
           <div class="hk-txn-item col-md-6" ng-repeat="txn in filteredManTxn = (managedTxn = (transactions | filter: {level: '!Ignore'}) | filter: { name: $root.sbFilter.search }) track by txn.name" ng-show="txn.level !== 'Ignore'" ng-class="{'disabled-txn-card': txn.level === 'None'}">
             <div class="card-pf">
               <div class="card-pf-title">
-                <span tooltip="No data being collected for this service. Activate it to collect." ng-show="txn.level === 'None'"><i class="glyphicon glyphicon-remove-sign"></i></span>
+                <span uib-tooltip="No data being collected for this service. Activate it to collect." ng-show="txn.level === 'None'"><i class="glyphicon glyphicon-remove-sign"></i></span>
                 <a href="/hawkular-ui/apm/btm/info/{{txn.name}}">{{txn.name}}</a>
                 <span class="hk-settings pull-right" ng-show="txn.staticConfig">
-                  <a href="/hawkular-ui/apm/btm/config/{{txn.name}}" tooltip="Configure"><i class="fa fa-cog"></i></a>
-                  <a href="#" ng-click="deleteTxn(txn)" tooltip="Delete"><i class="fa fa-trash-o"></i></a>
+                  <a href="/hawkular-ui/apm/btm/config/{{txn.name}}" uib-tooltip="Configure"><i class="fa fa-cog"></i></a>
+                  <a href="#" ng-click="deleteTxn(txn)" uib-tooltip="Delete"><i class="fa fa-trash-o"></i></a>
                 </span>
               </div>
               <div class="card-pf-body hk-summary">
@@ -88,21 +88,21 @@
                   <div class="col-sm-4 hk-summary-item">
                     <a href="/hawkular-ui/apm/btm/info/{{txn.name}}">
                       <span class="hk-data" ng-show="txn.count !== undefined">{{txn.count}}</span>
-                      <span class="hk-data spinner" ng-hide="txn.count !== undefined" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
+                      <span class="hk-data spinner" ng-hide="txn.count !== undefined" uib-popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
                       <span class="hk-item">Transactions</span>
                     </a>
                   </div>
                   <div class="col-sm-4 hk-summary-item">
                     <a href="/hawkular-ui/apm/btm/info/{{txn.name}}">
                       <span class="hk-data" ng-show="txn.percentile95 !== undefined">{{txn.percentile95 * 1000 * 1000 | hkDuration : true}}</span>
-                      <span class="hk-data spinner" ng-hide="txn.percentile95 !== undefined" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
-                      <span class="hk-item" tooltip="95th percentile" tooltip-append-to-body="true" tooltip-placement="bottom">Duration<span></span>
+                      <span class="hk-data spinner" ng-hide="txn.percentile95 !== undefined" uib-popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
+                      <span class="hk-item" uib-tooltip="95th percentile" tooltip-append-to-body="true" tooltip-placement="bottom">Duration<span></span>
                     </a>
                   </div>
                   <div class="col-sm-4 hk-summary-item">
                     <a href="/hawkular-ui/apm/btm/info/{{txn.name}}">
                       <span class="hk-data" ng-show="txn.faultcount !== undefined">{{txn.faultcount}}</span>
-                      <span class="hk-data spinner" ng-hide="txn.faultcount !== undefined" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
+                      <span class="hk-data spinner" ng-hide="txn.faultcount !== undefined" uib-popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
                       <span class="hk-item">Faults</span>
                     </a>
                   </div>

--- a/ui/src/main/scripts/plugins/btm/html/btxnconfig.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxnconfig.html
@@ -11,13 +11,13 @@
 
     <h1>{{transactionName}}</h1>
 
-    <alert ng-repeat="message in messages" type="{{getMessageType(message)}}" close="closeMessage($index)"><strong>{{getMessageText(message)}}</strong>
+    <uib-alert ng-repeat="message in messages" type="{{getMessageType(message)}}" close="closeMessage($index)"><strong>{{getMessageText(message)}}</strong>
       <div ng-hide="message.details === undefined">
         {{message.details}}
       </div>
-    </alert>
+    </uib-alert>
 
-    <a href="#" class="hk-transaction-description" editable-textarea="transaction.description" e-rows="3" e-cols="108" onaftersave="setDirty()" tooltip="Click to edit">
+    <a href="#" class="hk-transaction-description" editable-textarea="transaction.description" e-rows="3" e-cols="108" onaftersave="setDirty()" uib-tooltip="Click to edit">
       <span>{{ transaction.description || 'No description' }}</span>
     </a>
 
@@ -31,16 +31,16 @@
         <h4>Inclusion</h4>
         <!-- TODO: Use angular-ui/bootstrap typeahead to autofill possible inclusion URIs -->
         <ul class="list-group">
-          <li class="list-group-item" ng-repeat="inclusion in transaction.filter.inclusions" >{{inclusion}}<span class="glyphicon glyphicon-remove pull-right" aria-hidden="true" ng-click="removeInclusionFilter(inclusion)" tooltip="Remove"></span></li>
+          <li class="list-group-item" ng-repeat="inclusion in transaction.filter.inclusions" >{{inclusion}}<span class="glyphicon glyphicon-remove pull-right" aria-hidden="true" ng-click="removeInclusionFilter(inclusion)" uib-tooltip="Remove"></span></li>
           <li class="list-group-item clearfix">
             <form class="form-horizontal" name="addInclusionForm" role="form" autocomplete="off" ng-submit="addInclusionFilter()">
               <div class="input-group">
                 <input type="text" class="form-control" name="newInclusionFilterField"
                      ng-model="newInclusionFilter" ng-model-options="{ updateOn: 'default blur'}"
                      placeholder="Enter an inclusion filter (regular expression)"
-                     typeahead="endpoint for endpoint in unboundEndpoints | filter:$viewValue | limitTo:12" />
+                     uib-typeahead="endpoint for endpoint in unboundEndpoints | filter:$viewValue | limitTo:12" />
                 <span class="input-group-btn">
-                  <button class="btn btn-default" type="submit" ng-disabled="!newInclusionFilter"  tooltip="Add">
+                  <button class="btn btn-default" type="submit" ng-disabled="!newInclusionFilter"  uib-tooltip="Add">
                     <div ng-show="addProgress" class="spinner spinner-sm"></div>
                     <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                   </button>
@@ -54,16 +54,16 @@
       <div class="col-md-6" >
         <h4>Exclusion (applied after inclusions)</h4>
         <ul class="list-group">
-          <li class="list-group-item" ng-repeat="exclusion in transaction.filter.exclusions" >{{exclusion}}<span class="glyphicon glyphicon-remove pull-right" aria-hidden="true" ng-click="removeExclusionFilter(exclusion)" tooltip="Remove"></span></li>
+          <li class="list-group-item" ng-repeat="exclusion in transaction.filter.exclusions" >{{exclusion}}<span class="glyphicon glyphicon-remove pull-right" aria-hidden="true" ng-click="removeExclusionFilter(exclusion)" uib-tooltip="Remove"></span></li>
           <li class="list-group-item clearfix" >
             <form class="form-horizontal" name="addExclusionForm" role="form" autocomplete="off" novalidate="" ng-submit="addExclusionFilter()">
               <div class="input-group">
                 <input type="text" class="form-control" name="newExclusionFilterField"
                      ng-model="newExclusionFilter" ng-model-options="{ updateOn: 'default blur'}"
                      placeholder="Enter an exclusion filter (regular expression)"
-                     typeahead="endpoint for endpoint in unboundEndpoints | filter:$viewValue | limitTo:12" />
+                     uib-typeahead="endpoint for endpoint in unboundEndpoints | filter:$viewValue | limitTo:12" />
                 <span class="input-group-btn">
-                  <button class="btn btn-default" type="submit" ng-disabled="!newExclusionFilter" tooltip="Add">
+                  <button class="btn btn-default" type="submit" ng-disabled="!newExclusionFilter" uib-tooltip="Add">
                     <div ng-show="addProgress" class="spinner spinner-sm"></div>
                     <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                   </button>
@@ -93,9 +93,9 @@
 
       <div class="col-md-12" >
 
-        <accordion>
-          <accordion-group ng-repeat="processor in transaction.processors" is-open="false" is-disabled="false">
-            <accordion-heading>{{processor.description}} <a class="btn btn-link hk-delete pull-right" href="#" uibTooltip="Delete" tooltip-trigger="" tooltip-placement="top" ng-click="deleteProcessor(processor)"><i class="fa fa-trash-o"></i></a></accordion-heading>
+        <uib-accordion>
+          <uib-accordion-group ng-repeat="processor in transaction.processors" is-open="false" is-disabled="false">
+            <uib-accordion-heading>{{processor.description}} <a class="btn btn-link hk-delete pull-right" href="#" uib-tooltip="Delete" tooltip-placement="top" ng-click="deleteProcessor(processor)"><i class="fa fa-trash-o"></i></a></uib-accordion-heading>
 
             <form>
               <div class="form-group clearfix">
@@ -132,7 +132,7 @@
                   <input type="text" name="uriFilter" class="form-control"
                        ng-model="processor.uriFilter" ng-model-options="{ updateOn: 'default blur'}"
                        placeholder="Enter URI filter (regular expression)"
-                       typeahead="endpoint for endpoint in boundEndpoints | filter:$viewValue | limitTo:12"
+                       uib-typeahead="endpoint for endpoint in boundEndpoints | filter:$viewValue | limitTo:12"
                        ng-change="setDirty()" />
                 </div>
               </div>
@@ -202,8 +202,8 @@
               </div>
             </form>
 
-            <div dropdown="">
-              <a href="" id="simple-dropdown" dropdown-toggle="" class="btn btn-default hk-btn-accordeon-add">
+            <div uib-dropdown="">
+              <a href="" id="simple-dropdown" uib-dropdown-toggle="" class="btn btn-default hk-btn-accordeon-add">
                 Add Action
               </a>
               <ul class="dropdown-menu" aria-labelledby="simple-dropdown">
@@ -218,9 +218,9 @@
               </ul>
             </div>
 
-            <accordion>
-              <accordion-group ng-repeat="action in processor.actions" is-open="false" is-disabled="false">
-                <accordion-heading>[ {{action.actionType}} {{action.name}} ]: {{action.description}} <a class="btn btn-link hk-delete pull-right" href="#" tooltip="Delete" tooltip-trigger="" tooltip-placement="top" ng-click="deleteAction(processor,action)"><i class="fa fa-trash-o"></i></a></accordion-heading>
+            <uib-accordion>
+              <uib-accordion-group ng-repeat="action in processor.actions" is-open="false" is-disabled="false">
+                <uib-accordion-heading>[ {{action.actionType}} {{action.name}} ]: {{action.description}} <a class="btn btn-link hk-delete pull-right" href="#" uib-tooltip="Delete" tooltip-placement="top" ng-click="deleteAction(processor,action)"><i class="fa fa-trash-o"></i></a></uib-accordion-heading>
 
                 <form>
                   <div class="form-group clearfix">
@@ -381,11 +381,11 @@
 
                 </form>
 
-              </accordion-group>
-            </accordion>
+              </uib-accordion-group>
+            </uib-accordion>
 
-          </accordion-group>
-        </accordion>
+          </uib-accordion-group>
+        </uib-accordion>
       </div>
 
       <div class="col-md-12">

--- a/ui/src/main/scripts/plugins/btm/html/btxnignored.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxnignored.html
@@ -52,8 +52,8 @@
             <div class="panel-body">
               <a href="/hawkular-ui/apm/btm/info/{{txn.name}}" class="hk-panel-item">{{txn.name}}</a>
               <span class="hk-settings pull-right">
-                <a href="/hawkular-ui/apm/btm/config/{{txn.name}}" tooltip="Configure"><i class="fa fa-cog"></i></a>
-                <a href="#" ng-click="deleteTxn(txn)" tooltip="Delete"><i class="fa fa-trash-o"></i></a>
+                <a href="/hawkular-ui/apm/btm/config/{{txn.name}}" uib-tooltip="Configure"><i class="fa fa-cog"></i></a>
+                <a href="#" ng-click="deleteTxn(txn)" uib-tooltip="Delete"><i class="fa fa-trash-o"></i></a>
               </span>
             </div>
           </div>

--- a/ui/src/main/scripts/plugins/directives/dagre-d3/ts/dagreD3Directive.ts
+++ b/ui/src/main/scripts/plugins/directives/dagre-d3/ts/dagreD3Directive.ts
@@ -143,16 +143,16 @@ module DagreD3 {
         let res = inner.call(render, g);
 
         // add the tooltips aftewards, so they go on the <g> element
-        inner.selectAll('g.node.show-tt').on('mouseenter', null).attr('tooltip-append-to-body', 'true')
+        inner.selectAll('g.node.show-tt').attr('tooltip-append-to-body', 'true')
                                   .attr('tooltip-class', 'graph-tooltip')
-                                  .attr('tooltip-html', (d) => {
+                                  .attr('uib-tooltip-html', (d) => {
                                     let tooltipId = d.replace(/\W+/g, '_');
                                     return tooltipId;
                                   });
 
         inner.selectAll('g.edgeLabel').attr('tooltip-append-to-body', 'true')
                                       .attr('tooltip-class', 'graph-tooltip')
-                                      .attr('tooltip-html', (d) => {
+                                      .attr('uib-tooltip-html', (d) => {
                                         let tooltipId = d.v.replace(/\W+/g, '_') + '___' + d.w.replace(/\W+/g, '_');
                                         return tooltipId;
                                       });

--- a/ui/src/main/scripts/plugins/directives/filter-sidebar/html/filter-sidebar.html
+++ b/ui/src/main/scripts/plugins/directives/filter-sidebar/html/filter-sidebar.html
@@ -46,7 +46,7 @@
 
     <div class="hk-filter-v-block" ng-if="fsb.showBtxns">
       <label><button class="btn-link" ng-click="showSearchBtxn = !showSearchBtxn"><i class="fa" ng-class="showSearchBtxn ? 'fa-angle-right' : 'fa-angle-down'"></i>Transaction</button></label>
-      <div collapse="showSearchBtxn">
+      <div uib-collapse="showSearchBtxn">
         <div class="radio">
           <label><input type="radio" name="txn" ng-model="$root.sbFilter.criteria.transaction" value="" checked> All </label>
         </div>
@@ -58,7 +58,7 @@
 
     <div class="hk-filter-v-block" ng-show="fsb.showProps">
       <label><button class="btn-link" ng-click="showSearchProp = !showSearchProp"><i class="fa" ng-class="showSearchProp ? 'fa-angle-right' : 'fa-angle-down'"></i>Properties</button></label>
-      <div collapse="showSearchProp">
+      <div uib-collapse="showSearchProp">
 
         <ul ng-repeat="(type, value) in $root.sbFilter.criteria.properties | groupBy: 'name'" class="fa-ul">
           <label class="sb-prop-title">{{ type }}</label>
@@ -86,10 +86,10 @@
             <label> Value </label>
             <div class="input-group">
               <!-- <span class="input-group-addon">Value</span> -->
-              <input collapse="showSearchHost" type="text" class="form-control" name="propValueField"
+              <input uib-collapse="showSearchHost" type="text" class="form-control" name="propValueField"
                 ng-model="$root.sbFilter.selPropValue" ng-model-options="{ updateOn: 'default blur' }"
                 placeholder="Type '{{$root.sbFilter.selPropName.name}}' value" typeahead-editable="false"
-                typeahead="propValue.value for propValue in sbPropertyValues | filter:$viewValue | limitTo:12" />
+                uib-typeahead="propValue.value for propValue in sbPropertyValues | filter:$viewValue | limitTo:12" />
               <div class="input-group-btn">
                 <button type="button" class="btn btn-default" ng-disabled="!$root.sbFilter.selPropValue"
                   ng-click="addPropertyToFilter($root.sbFilter.selPropName.name, $root.sbFilter.selPropValue, 'HAS')">
@@ -113,10 +113,10 @@
 
     <div class="hk-filter-v-block" ng-class="{'has-error': invalidHostname}" ng-if="fsb.showHosts">
       <label><button class="btn-link" ng-click="showSearchHost = !showSearchHost"><i class="fa" ng-class="showSearchHost ? 'fa-angle-right' : 'fa-angle-down'"></i>Host Name</button></label>
-      <input collapse="showSearchHost" type="text" class="form-control" name="hostNameField"
+      <input uib-collapse="showSearchHost" type="text" class="form-control" name="hostNameField"
          ng-model="$root.sbFilter.criteria.hostName" ng-model-options="{ updateOn: 'default blur' }"
          placeholder="Enter a host name" typeahead-editable="false" typeahead-min-length="0"
-         typeahead="hostName for hostName in $root.sbFilter.data.hostNames | filter:$viewValue | limitTo:12" typeahead-no-results="invalidHostname" />
+         uib-typeahead="hostName for hostName in $root.sbFilter.data.hostNames | filter:$viewValue | limitTo:12" typeahead-no-results="invalidHostname" />
     </div>
 
   </div>
@@ -162,7 +162,7 @@
       <uib-accordion-heading>
         Transaction <span class="pull-right">{{ $root.sbFilter.criteria.transaction || "All" }}</span>
       </uib-accordion-heading>
-      <div collapse="showSearchBtxn">
+      <div uib-collapse="showSearchBtxn">
         <div class="radio">
           <label><input type="radio" name="txn-msb" ng-model="$root.sbFilter.criteria.transaction" value="" checked> All </label>
         </div>
@@ -202,10 +202,10 @@
           <label> Value </label>
           <div class="input-group" style="display: table; width: 100%;">
             <!-- <span class="input-group-addon">Value</span> -->
-            <input collapse="showSearchHost" type="text" class="form-control" name="propValueField"
+            <input uib-collapse="showSearchHost" type="text" class="form-control" name="propValueField"
               ng-model="$root.sbFilter.selPropValue" ng-model-options="{ updateOn: 'default blur' }"
               placeholder="Type '{{$root.sbFilter.selPropName.name}}' value" typeahead-editable="false"
-              typeahead="propValue.value for propValue in sbPropertyValues | filter:$viewValue | limitTo:12" style="width: calc(100% - 45px);" />
+              uib-typeahead="propValue.value for propValue in sbPropertyValues | filter:$viewValue | limitTo:12" style="width: calc(100% - 45px);" />
             <div class="input-group-btn" style="clear: initial;">
               <button type="button" class="btn btn-default" ng-disabled="!$root.sbFilter.selPropValue"
                 ng-click="addPropertyToFilter($root.sbFilter.selPropName.name, $root.sbFilter.selPropValue, 'HAS')">
@@ -231,10 +231,10 @@
         Host Name <span class="pull-right">{{ $root.sbFilter.criteria.hostName | limitTo: 20 }}<span ng-show="$root.sbFilter.search.length > 20">...</span></span>
       </uib-accordion-heading>
       <div class="hk-filter-v-block" ng-class="{'has-error': invalidHostname}">
-        <input collapse="showSearchHost" type="text" class="form-control" name="hostNameField"
+        <input uib-collapse="showSearchHost" type="text" class="form-control" name="hostNameField"
          ng-model="$root.sbFilter.criteria.hostName" ng-model-options="{ updateOn: 'default blur' }"
          placeholder="Enter a host name" typeahead-editable="false" typeahead-min-length="0"
-         typeahead="hostName for hostName in $root.sbFilter.data.hostNames | filter:$viewValue | limitTo:12" typeahead-no-results="invalidHostname" />
+         uib-typeahead="hostName for hostName in $root.sbFilter.data.hostNames | filter:$viewValue | limitTo:12" typeahead-no-results="invalidHostname" />
       </div>
     </uib-accordion-group>
   </uib-accordion>

--- a/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
+++ b/ui/src/main/scripts/plugins/directives/instance-view-diagram/ts/instanceViewDiagramDirective.ts
@@ -305,7 +305,7 @@ module InstanceViewDiagram {
         // add the tooltips aftewards, so they go on the <g> element
         inner.selectAll('g.node.show-tt').attr('tooltip-append-to-body', 'true')
                                           .attr('tooltip-class', 'graph-tooltip')
-                                          .attr('tooltip-html', (d) => {
+                                          .attr('uib-tooltip-html', (d) => {
                                             let tooltipId = d.replace(/\W+/g, '_');
                                             return tooltipId;
                                           });

--- a/ui/src/main/scripts/plugins/e2e/html/details-modal.html
+++ b/ui/src/main/scripts/plugins/e2e/html/details-modal.html
@@ -65,7 +65,7 @@
             <td class="inst-details-timestamp">{{ tData.timestamp | date:'medium' }}</td>
             <!--<td>{{ tData.uri }}</td>-->
             <td class="inst-details-properties">
-              <span class="label label-default" ng-repeat="tDataProp in tData.propertiesGrouped" ng-click="tDataProp.expand = !tDataProp.expand" tooltip="{{tDataProp.name}} : {{tDataProp.value}}"  ng-if="!!tDataProp.value">
+              <span class="label label-default" ng-repeat="tDataProp in tData.propertiesGrouped" ng-click="tDataProp.expand = !tDataProp.expand" uib-tooltip="{{tDataProp.name}} : {{tDataProp.value}}"  ng-if="!!tDataProp.value">
                 {{tDataProp.name}}:<span ng-hide="tDataProp.expand">{{ tDataProp.value | limitTo:16}}<span ng-show="!tDataProp.expand && tDataProp.value.length > 16">...</span></span><span ng-show="tDataProp.expand">{{ tDataProp.value }}</span>
               </span>
             </td>

--- a/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
+++ b/ui/src/main/scripts/plugins/e2e/ts/e2e.ts
@@ -21,8 +21,8 @@ module E2E {
   declare let dagreD3: any;
 
   export let E2EController = _module.controller('E2E.E2EController', ['$scope', '$rootScope', '$routeParams', '$http',
-    '$location', '$interval', '$timeout', '$modal', ($scope, $rootScope, $routeParams, $http, $location, $interval,
-    $timeout, $modal) => {
+    '$location', '$interval', '$timeout', '$uibModal', ($scope, $rootScope, $routeParams, $http, $location, $interval,
+    $timeout, $uibModal) => {
 
     $scope.reload = function() {
 
@@ -123,7 +123,7 @@ module E2E {
       }
     };
 
-    let ModalInstanceCtrl = function ($scope, $modalInstance, $log, rootNode, topLevel, uris, operations) {
+    let ModalInstanceCtrl = function ($scope, $uibModalInstance, $log, rootNode, topLevel, uris, operations) {
 
       $scope.rootNode = {
         'uri': rootNode
@@ -224,12 +224,12 @@ module E2E {
       };
 
       $scope.close = function() {
-        $modalInstance.dismiss('cancel');
+        $uibModalInstance.dismiss('cancel');
       };
     };
 
     $scope.showInstanceDetails = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'plugins/e2e/html/details-modal.html',
         controller: ModalInstanceCtrl,
         size: 'xl',


### PR DESCRIPTION
While navigating the page, multiple warnings are visible in the browser console due to using old style directives (not namespaced with uib-), this fixes it.

@objectiser please have a look at the whole page, and see if everything is working properly and no warnings are shown. I've done it myself, but better double check.