### PR TITLE
Fix HAWKULAR_APM_TENANT_ID env variable

### DIFF
--- a/client/api/src/main/java/org/hawkular/apm/client/api/recorder/BatchTraceRecorder.java
+++ b/client/api/src/main/java/org/hawkular/apm/client/api/recorder/BatchTraceRecorder.java
@@ -44,7 +44,7 @@ public class BatchTraceRecorder implements TraceRecorder {
     private static final int DEFAULT_BATCH_THREAD_POOL_SIZE = 5;
     private static final int DEFAULT_BATCH_TIME = 500;
     private static final int DEFAULT_BATCH_SIZE = 1000;
-    private static final String HAWKULAR_APM_TENANT_ID = "HAWKULAR_APM_TENANTID";
+    private static final String HAWKULAR_APM_TENANT_ID = "HAWKULAR_APM_TENANT_ID";
 
     private TracePublisher tracePublisher;
 

--- a/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollectorTest.java
+++ b/client/collector/src/test/java/org/hawkular/apm/client/collector/internal/DefaultTraceCollectorTest.java
@@ -117,7 +117,7 @@ public class DefaultTraceCollectorTest {
 
         Wait.until(() -> traceService.getTraces().size() == 1);
         // Clear property
-        System.getProperties().remove("HAWKULAR_APM_TENANTID");
+        System.getProperties().remove("HAWKULAR_APM_TENANT_ID");
 
         assertNotNull("TenantId should not be null", traceService.getTenantId());
 


### PR DESCRIPTION
This would make the `HAWKULAR_APM_TENANT_ID` environment variable consistent with other references.